### PR TITLE
Atb2020 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ conda activate powergenome
 pip install -e .
 ```
 
-5. Download a [modifed version of the PUDL database](https://drive.google.com/open?id=17hTZUKweDMqUi2wvBdubaqVhMRgnN5o5) that includes NREL ATB cost data and is not yet included in PUDL.
+5. Download a [modifed version of the PUDL database](https://drive.google.com/file/d/1DamR83bR9DyY-gdXac6xYnp5iFhhzgO4/view?usp=sharing) that includes NREL ATB cost data and is not yet included in PUDL. **NOTE: this database was updated for PowerGenome v0.4.0 and is not compatable with earlier versions.** 
 
 6. Download the [renewable resource data](https://drive.google.com/file/d/1g0Q6TdNp4C12HQJy6pAURzp_oVg0Q7ly/view?usp=sharing) containing generation profiles and capacity for existing and new-build renewable resources. Save and unzip this file. The suggested location for all of the unzipped files is `PowerGenome/data/resource_groups/`. These files will eventually be provided through a data repository with citation information.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you have previously installed PowerGenome and the `run_powergenome_multiple` 
 
 ## Licensing
 
-PowerGenome is released under the [MIT License](https://opensource.org/licenses/MIT). Most data inputs are from US government sources (EIA, EPA, FERC, etc), which should not be [subject to copyright in the US](https://www.usa.gov/government-works). Hourly generation profiles for wind and solar resources were created by [Vibrant Clean Energy](https://www.vibrantcleanenergy.com/) and provided without usage restrictions. All PowerGenome data outputs are released under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode) license.
+PowerGenome is released under the [MIT License](https://opensource.org/licenses/MIT). Most data inputs are from US government sources (EIA, EPA, FERC, etc), which should not be [subject to copyright in the US](https://www.usa.gov/government-works). Hourly FERC demand data has been cleaned using [techniques](https://github.com/truggles/EIA_Cleaned_Hourly_Electricity_Demand_Code) developed by Tyler Ruggles and David Farnham, and allocated to IPM regions using [methods developed](https://github.com/catalyst-cooperative/electricity-demand-mapping) by Catalyst Cooperative. Hourly generation profiles for wind and solar resources were created by [Vibrant Clean Energy](https://www.vibrantcleanenergy.com/) and provided without usage restrictions. All PowerGenome data outputs are released under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode) license.
 
 ## Contributing
 

--- a/data/additional_technologies/AZ_additional_tech.csv
+++ b/data/additional_technologies/AZ_additional_tech.csv
@@ -1,4 +1,4 @@
-﻿technology,planning_year,capex,capex_mwh,o_m_fixed_mw,o_m_fixed_mwh,o_m_variable_mwh,waccnomtech,dollar_year,heat_rate,notes
+﻿technology,planning_year,capex_mw,capex_mwh,fixed_o_m_mw,fixed_o_m_mwh,variable_o_m_mwh,wacc_nominal,dollar_year,heat_rate,notes
 Nuclear_mid,2030,5885000,0,100889,0,2.314,0.071893686,2017,10.461,construction finance factor of 1.07 from ATB geothermal example with 5 years construction time
 Nuclear_low,2030,3066000,0,100889,0,2.314,0.071893686,2017,10.461,construction finance factor of 1.022 from ATB natural gas example with 3 years construction time
 Nuclear_high,2030,11540000,0,100889,0,2.314,0.071893686,2017,10.461,construction finance factor of 1.154 for 10% construction in every year for 10 years

--- a/data/additional_technologies/sample_additional_tech.csv
+++ b/data/additional_technologies/sample_additional_tech.csv
@@ -1,4 +1,4 @@
-﻿technology,planning_year,capex,capex_mwh,o_m_fixed_mw,o_m_fixed_mwh,o_m_variable_mwh,waccnomtech,dollar_year,heat_rate,notes
+﻿technology,planning_year,capex_mw,capex_mwh,fixed_o_m_mw,fixed_o_m_mwh,variable_o_m_mwh,wacc_nominal,dollar_year,heat_rate,notes
 Nuclear_mid,2030,5885000,0,100889,0,2.314,0.071893686,2017,10.461,construction finance factor of 1.07 from ATB geothermal example with 5 years construction time
 Nuclear_low,2030,3066000,0,100889,0,2.314,0.071893686,2017,10.461,construction finance factor of 1.022 from ATB natural gas example with 3 years construction time
 Nuclear_high,2030,10790000,0,100889,0,2.314,0.071893686,2017,10.461,construction finance factor of 1.079 from ATB geothermal example with 10 years construction time

--- a/example_system/test_settings.yml
+++ b/example_system/test_settings.yml
@@ -172,31 +172,31 @@ settings_management:
           ngccccs:
             technology: NaturalGas
             tech_detail: CCCCSAvgCF
-            capex: [mul, 1]
+            capex_mw: [mul, 1]
           NGCCS100:
             technology: NaturalGas
             tech_detail: CCS100
-            capex: [mul, 1]
+            capex_mw: [mul, 1]
       low:
         atb_modifiers:
           ngccccs:
             technology: NaturalGas
             tech_detail: CCCCSAvgCF
-            capex: [mul, 0.85]
+            capex_mw: [mul, 0.85]
           NGCCS100:
             technology: NaturalGas
             tech_detail: CCS100
-            capex: [mul, 0.85]
+            capex_mw: [mul, 0.85]
       high:
         atb_modifiers:
           ngccccs:
             technology: NaturalGas
             tech_detail: CCCCSAvgCF
-            capex: [mul, 1.2]
+            capex_mw: [mul, 1.2]
           NGCCS100:
             technology: NaturalGas
             tech_detail: CCS100
-            capex: [mul, 1.2]
+            capex_mw: [mul, 1.2]
     renewable_capex:
       mid:
         atb_new_gen:
@@ -279,31 +279,31 @@ settings_management:
           ngccccs:
             technology: NaturalGas
             tech_detail: CCCCSAvgCF
-            capex: [mul, 1]
+            capex_mw: [mul, 1]
           NGCCS100:
             technology: NaturalGas
             tech_detail: CCS100
-            capex: [mul, 1]
+            capex_mw: [mul, 1]
       low:
         atb_modifiers:
           ngccccs:
             technology: NaturalGas
             tech_detail: CCCCSAvgCF
-            capex: [mul, 0.8]
+            capex_mw: [mul, 0.8]
           NGCCS100:
             technology: NaturalGas
             tech_detail: CCS100
-            capex: [mul, 0.8]
+            capex_mw: [mul, 0.8]
       high:
         atb_modifiers:
           ngccccs:
             technology: NaturalGas
             tech_detail: CCCCSAvgCF
-            capex: [mul, 1.15]
+            capex_mw: [mul, 1.15]
           NGCCS100:
             technology: NaturalGas
             tech_detail: CCS100
-            capex: [mul, 1.15]
+            capex_mw: [mul, 1.15]
     renewable_capex:
       mid:
         atb_new_gen:
@@ -676,6 +676,7 @@ regional_tag_values:
 
 # Generator cost data from NREL ATB
 
+atb_data_year: 2020
 atb_cost_case: Mid
 atb_financial_case: Market
 atb_cap_recovery_years: 20
@@ -703,16 +704,14 @@ atb_modifiers:
   ngct:
     technology: NaturalGas
     tech_detail: CTAvgCF
-    capex: [mul, 0.76]
-    # Inv_cost_per_MWyr: 0.76
-    Var_OM_cost_per_MWh: [mul, 1.51]
-    Fixed_OM_cost_per_MWyr: [mul, 0.56]
-    Heat_rate_MMBTU_per_MWh: [mul, 0.97]
+    capex_mw: [mul, 0.76]
+    Var_OM_cost_per_MWh: [mul, 0.98]
+    Fixed_OM_cost_per_MWyr: [mul, 0.6]
+    Heat_rate_MMBTU_per_MWh: [mul, 1.04]
   ngcc:
     technology: NaturalGas
     tech_detail: CCAvgCF
-    capex: [mul, 0.89]
-    # Inv_cost_per_MWyr: 0.89
+    capex_mw: [mul, 0.89]
     Var_OM_cost_per_MWh: [mul, 0.73]
     Fixed_OM_cost_per_MWyr: [mul, 0.95]
     Heat_rate_MMBTU_per_MWh: [mul, 0.98]
@@ -730,9 +729,9 @@ modified_atb_new_gen:
     atb_tech_detail: CCCCSAvgCF
     atb_cost_case: Mid
     size_mw: 500
-    capex: [add, 116000]
+    capex_mw: [add, 116000]
     heat_rate: [add, 0.365]
-    o_m_fixed_mw: [add, 9670]
+    fixed_o_m_mw: [add, 9670]
     o_m_variable_mwh: [mul, 1.076]
 
 # ATB doesn't have a WACC for battery tech. Need to provide a value here.
@@ -1187,7 +1186,7 @@ generator_columns: [
             "Max_Cap_MW",
             "Min_Share_percent",
             "Max_Share_percent",
-            "capex",
+            "capex_mw",
             "Inv_cost_per_MWyr",
             "Fixed_OM_cost_per_MWyr",
             "capex_mwh",

--- a/example_system/test_settings.yml
+++ b/example_system/test_settings.yml
@@ -365,6 +365,10 @@ data_years:
 
 target_usd_year: 2017
 
+# HOURS OFFSET FROM UTC
+# All time profile data are stored in UTC. Provide an offset for the model timezone.
+utc_offset: -5
+
 # CAPACITY TYPE
 capacity_col: winter_capacity_mw
 
@@ -732,7 +736,7 @@ modified_atb_new_gen:
     capex_mw: [add, 116000]
     heat_rate: [add, 0.365]
     fixed_o_m_mw: [add, 9670]
-    o_m_variable_mwh: [mul, 1.076]
+    variable_o_m_mwh: [mul, 1.076]
 
 # ATB doesn't have a WACC for battery tech. Need to provide a value here.
 atb_battery_wacc: UtilityPV

--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -278,7 +278,7 @@ def reduce_time_domain(
         reduced_resource_profile.index.name = "Resource"
         reduced_resource_profile.index = range(1, len(reduced_resource_profile) + 1)
         reduced_load_profile = results["load_profiles"]
-        long_duration_storage = results["long_duration_storage"]
+        time_series_mapping = results["time_series_mapping"]
 
         time_index = pd.Series(data=reduced_load_profile.index + 1, name="Time_index")
         sub_weights = pd.Series(
@@ -299,7 +299,7 @@ def reduce_time_domain(
             axis=1,
         )
 
-        return reduced_resource_profile, reduced_load_output, long_duration_storage
+        return reduced_resource_profile, reduced_load_output, time_series_mapping
 
     else:
         time_index = pd.Series(data=range(1, 8761), name="Time_index")

--- a/powergenome/external_data.py
+++ b/powergenome/external_data.py
@@ -377,7 +377,7 @@ def overwrite_wind_pv_capacity(df, settings):
 
     wind_pv_ipm_region_capacity = pd.read_csv(path)
 
-    region_agg_map = reverse_dict_of_lists(settings.get("region_aggregations"))
+    region_agg_map = reverse_dict_of_lists(settings.get("region_aggregations", {}))
 
     # Set model_region as IPM_region to start
     wind_pv_ipm_region_capacity["model_region"] = wind_pv_ipm_region_capacity[

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -1177,6 +1177,9 @@ def calc_unit_cluster_values(df, settings, technology=None):
     df_values["heat_rate_mmbtu_mwh_std"] = df.groupby("cluster").agg(
         {"heat_rate_mmbtu_mwh": "std"}
     )
+    df_values["fixed_o_m_mw_std"] = df.groupby("cluster").agg(
+        {"Fixed_OM_cost_per_MWyr": "std"}
+    )
 
     df_values["Min_power"] = (
         df_values["minimum_load_mw"] / df_values[settings["capacity_col"]]

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -2203,7 +2203,7 @@ class GeneratorClusters:
                 self.units_model.technology_description == tech, "heat_rate_mmbtu_mwh"
             ] = self.fill_na_heat_rates(
                 self.units_model.loc[
-                    self.units_model.technology_description == tech, 
+                    self.units_model.technology_description == tech,
                     "heat_rate_mmbtu_mwh",
                 ]
             )
@@ -2519,7 +2519,6 @@ class GeneratorClusters:
         self.atb_costs = fetch_atb_costs(
             self.pudl_engine, self.settings, self.offshore_spur_costs
         )
-        
 
         self.new_generators = atb_new_generators(
             self.atb_costs, self.atb_hr, self.settings

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -1993,7 +1993,7 @@ class GeneratorClusters:
         self.fuel_prices = fetch_fuel_prices(self.settings)
         self.atb_hr = fetch_atb_heat_rates(self.pudl_engine, self.settings)
 
-    def fill_na_heat_rates(self, df):
+    def fill_na_heat_rates(self, s):
         """Fill null heat rate values with the median of the series. Not many null
         values are expected.
 
@@ -2007,11 +2007,15 @@ class GeneratorClusters:
         Dataframe
             Same as input but with any null values replaced by the median.
         """
+        if s.isnull().any():
+            median_hr = s.median()
+            return s.fillna(median_hr)
+        else:
+            return s
+        # median_hr = df["heat_rate_mmbtu_mwh"].median()
+        # df["heat_rate_mmbtu_mwh"].fillna(median_hr, inplace=True)
 
-        median_hr = df["heat_rate_mmbtu_mwh"].median()
-        df["heat_rate_mmbtu_mwh"].fillna(median_hr, inplace=True)
-
-        return df
+        # return df
 
     def create_demand_response_gen_rows(self):
         """Create rows for demand response/management resources to include in the
@@ -2193,9 +2197,12 @@ class GeneratorClusters:
         # Fill any null heat rate values for each tech
         for tech in self.units_model["technology_description"]:
             self.units_model.loc[
-                self.units_model.technology_description == tech, :
+                self.units_model.technology_description == tech, "heat_rate_mmbtu_mwh"
             ] = self.fill_na_heat_rates(
-                self.units_model.loc[self.units_model.technology_description == tech, :]
+                self.units_model.loc[
+                    self.units_model.technology_description == tech, 
+                    "heat_rate_mmbtu_mwh",
+                ]
             )
         # assert (
         #     self.units_model["heat_rate_mmbtu_mwh"].isnull().any() is False

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -2503,7 +2503,11 @@ class GeneratorClusters:
             if not metadata["ipm_region"].isin(ipm_regions).any():
                 # Resource group has no resources in selected IPM regions
                 continue
-            clusters = group.get_clusters(ipm_regions=ipm_regions, max_clusters=1)
+            clusters = group.get_clusters(
+                ipm_regions=ipm_regions,
+                max_clusters=1,
+                utc_offset=self.settings.get("utc_offset", 0),
+            )
             self.results["profile"][i] = clusters["profile"][0]
 
         return self.results

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -2250,7 +2250,6 @@ class GeneratorClusters:
             .query("technology.isin(@techs).values")
             .pipe(
                 atb_fixed_var_om_existing,
-                self.atb_costs,
                 self.atb_hr,
                 self.settings,
                 self.pudl_engine,

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -2248,7 +2248,13 @@ class GeneratorClusters:
         self.units_model = (
             self.units_model.rename(columns={"technology_description": "technology"})
             .query("technology.isin(@techs).values")
-            .pipe(atb_fixed_var_om_existing, self.atb_costs, self.atb_hr, self.settings)
+            .pipe(
+                atb_fixed_var_om_existing,
+                self.atb_costs,
+                self.atb_hr,
+                self.settings,
+                self.pudl_engine,
+            )
         )
 
         # logger.info(

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -1990,15 +1990,6 @@ class GeneratorClusters:
             # self.utilities_eia = load_utilities_eia(self.pudl_engine)
         else:
             self.existing_resources = pd.DataFrame()
-
-        self.offshore_spur_costs = fetch_atb_offshore_spur_costs(
-            self.pudl_engine, self.settings
-        )
-        self.atb_costs = fetch_atb_costs(
-            self.pudl_engine, self.settings, self.offshore_spur_costs
-        )
-        self.atb_hr = fetch_atb_heat_rates(self.pudl_engine)
-
         self.fuel_prices = fetch_fuel_prices(self.settings)
 
     def fill_na_heat_rates(self, df):
@@ -2507,6 +2498,13 @@ class GeneratorClusters:
         return self.results
 
     def create_new_generators(self):
+        self.offshore_spur_costs = fetch_atb_offshore_spur_costs(
+            self.pudl_engine, self.settings
+        )
+        self.atb_costs = fetch_atb_costs(
+            self.pudl_engine, self.settings, self.offshore_spur_costs
+        )
+        self.atb_hr = fetch_atb_heat_rates(self.pudl_engine, self.settings)
 
         self.new_generators = atb_new_generators(
             self.atb_costs, self.atb_hr, self.settings
@@ -2565,9 +2563,7 @@ class GeneratorClusters:
         self.all_resources = self.all_resources.reset_index(drop=True)
         self.all_resources["variable_CF"] = 0.0
         for i, p in enumerate(self.all_resources["profile"]):
-            if isinstance(
-                p, (collections.Sequence, np.ndarray)
-            ):
+            if isinstance(p, (collections.Sequence, np.ndarray)):
                 self.all_resources.loc[i, "variable_CF"] = np.mean(p)
 
         # Set Min_power of wind/solar to 0

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -1991,6 +1991,7 @@ class GeneratorClusters:
         else:
             self.existing_resources = pd.DataFrame()
         self.fuel_prices = fetch_fuel_prices(self.settings)
+        self.atb_hr = fetch_atb_heat_rates(self.pudl_engine, self.settings)
 
     def fill_na_heat_rates(self, df):
         """Fill null heat rate values with the median of the series. Not many null
@@ -2504,7 +2505,7 @@ class GeneratorClusters:
         self.atb_costs = fetch_atb_costs(
             self.pudl_engine, self.settings, self.offshore_spur_costs
         )
-        self.atb_hr = fetch_atb_heat_rates(self.pudl_engine, self.settings)
+        
 
         self.new_generators = atb_new_generators(
             self.atb_costs, self.atb_hr, self.settings

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -9,7 +9,6 @@ import pandas as pd
 from powergenome.util import (
     regions_to_keep,
     reverse_dict_of_lists,
-    shift_wrap_profiles,
     remove_feb_29,
 )
 from powergenome.external_data import make_demand_response_profiles

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -60,6 +60,10 @@ def make_load_curves(
 
     if len(lc_wide) == 8784:
         lc_wide = remove_feb_29(lc_wide)
+    
+    # Shift load from UTC
+    for col in lc_wide:
+        lc_wide[col] = np.roll(lc_wide[col].values, settings.get("utc_offset", 0))
 
     lc_wide.index.name = "time_index"
     if lc_wide.index.min() == 0:

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -5,6 +5,7 @@ Hourly demand profiles
 import logging
 from pathlib import Path
 import pandas as pd
+import numpy as np
 
 from powergenome.util import (
     regions_to_keep,

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -184,7 +184,7 @@ def fetch_atb_costs(
 
     # Transform from tidy to wide dataframe, which makes it easier to fill generator
     # rows with the correct values.
-    atb_costs = df.set_index(
+    atb_costs = df.drop_duplicates().set_index(
         [
             "technology",
             "tech_detail",

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -614,8 +614,8 @@ def atb_fixed_var_om_existing(
                 ]
             if "Nuclear" in eia_tech:
                 age = (settings["model_year"] - _df.operating_date.dt.year).values
-                age = age.fillna(age.mean())
-                age = age.fillna(40)
+                # age = age.fillna(age.mean())
+                # age = age.fillna(40)
                 # EIA, 2020, "Assumptions to Annual Energy Outlook, Electricity Market Module,"
                 # Available: https://www.eia.gov/outlooks/aeo/assumptions/pdf/electricity.pdf
                 fixed = np.ones_like(age)

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -1052,6 +1052,7 @@ def atb_new_generators(atb_costs, atb_hr, settings):
         "Fixed_OM_cost_per_MWhyr",
         "Inv_cost_per_MWyr",
         "Inv_cost_per_MWhyr",
+        "cluster"
     ]
     results = results.fillna(0)
     results[int_cols] = results[int_cols].astype(int)

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -184,16 +184,20 @@ def fetch_atb_costs(
 
     # Transform from tidy to wide dataframe, which makes it easier to fill generator
     # rows with the correct values.
-    atb_costs = df.drop_duplicates().set_index(
-        [
-            "technology",
-            "tech_detail",
-            "cost_case",
-            "dollar_year",
-            "basis_year",
-            "parameter",
-        ]
-    ).unstack(level=-1)
+    atb_costs = (
+        df.drop_duplicates()
+        .set_index(
+            [
+                "technology",
+                "tech_detail",
+                "cost_case",
+                "dollar_year",
+                "basis_year",
+                "parameter",
+            ]
+        )
+        .unstack(level=-1)
+    )
     atb_costs.columns = atb_costs.columns.droplevel(0)
     atb_costs = (
         atb_costs.reset_index()
@@ -627,7 +631,7 @@ def atb_fixed_var_om_existing(
 
                 # Operating costs for different size/num units in 2016 INL report
                 # "Economic and Market Challenges Facing the U.S. Nuclear Fleet"
-                # https://gain.inl.gov/Shared%20Documents/Economics-Nuclear-Fleet.pdf, 
+                # https://gain.inl.gov/Shared%20Documents/Economics-Nuclear-Fleet.pdf,
                 # table 1. Average of the two costs are used in each case.
                 # The costs in that report include fuel and VOM. Assume $0.66/mmbtu
                 # and $2.32/MWh plus 90% CF (ATB 2020) to get the costs below.
@@ -647,9 +651,7 @@ def atb_fixed_var_om_existing(
                 # fixed[age < 30] *= 27 * 1000
                 # fixed[age >= 30] *= (27+37) * 1000
 
-                _df[
-                    "Fixed_OM_cost_per_MWyr"
-                ] = inflation_price_adjustment(
+                _df["Fixed_OM_cost_per_MWyr"] = inflation_price_adjustment(
                     fixed, 2015, target_usd_year
                 )
                 _df["Var_OM_cost_per_MWh"] = atb_var_om_mwh * (
@@ -1052,7 +1054,7 @@ def atb_new_generators(atb_costs, atb_hr, settings):
         "Fixed_OM_cost_per_MWhyr",
         "Inv_cost_per_MWyr",
         "Inv_cost_per_MWhyr",
-        "cluster"
+        "cluster",
     ]
     results = results.fillna(0)
     results[int_cols] = results[int_cols].astype(int)

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -1135,7 +1135,10 @@ def add_renewables_clusters(
         scenario.pop("region")
         clusters = (
             CLUSTER_BUILDER.get_clusters(
-                **scenario, ipm_regions=ipm_regions, existing=False
+                **scenario,
+                ipm_regions=ipm_regions,
+                existing=False,
+                utc_offset=settings.get("utc_offset", 0),
             )
             .rename(columns={"mw": "Max_Cap_MW"})
             .assign(technology=technology, region=region)

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -574,6 +574,8 @@ def atb_fixed_var_om_existing(
                 assert plant_capacity > 0
 
                 age = settings["model_year"] - _df.operating_date.dt.year
+                age = age.fillna(age.mean())
+                age = age.fillna(40)
 
                 # https://www.eia.gov/analysis/studies/powerplants/generationcost/pdf/full_report.pdf
                 annual_capex = (16.53 + (0.126 * age) + (5.68 * 0.5)) * 1000
@@ -612,6 +614,8 @@ def atb_fixed_var_om_existing(
                 ]
             if "Nuclear" in eia_tech:
                 age = (settings["model_year"] - _df.operating_date.dt.year).values
+                age = age.fillna(age.mean())
+                age = age.fillna(40)
                 # EIA, 2020, "Assumptions to Annual Energy Outlook, Electricity Market Module,"
                 # Available: https://www.eia.gov/outlooks/aeo/assumptions/pdf/electricity.pdf
                 fixed = np.ones_like(age)

--- a/powergenome/resource_clusters.py
+++ b/powergenome/resource_clusters.py
@@ -504,6 +504,7 @@ class ResourceGroup:
         max_lcoe: float = None,
         cap_multiplier: float = None,
         profiles: bool = True,
+        utc_offset: int = 0,
     ) -> pd.DataFrame:
         """
         Compute resource clusters.
@@ -585,7 +586,10 @@ class ResourceGroup:
         # Prepare profiles
         if profiles and self.profiles is not None:
             df["profile"] = list(
-                self.profiles.read(columns=df.index.astype(str)).values.T
+                np.roll(
+                    self.profiles.read(columns=df.index.astype(str)).values.T,
+                    -utc_offset,
+                )
             )
             merge["means"].append("profile")
         # Compute clusters
@@ -690,6 +694,7 @@ class ClusterBuilder:
         max_clusters: int = None,
         max_lcoe: float = None,
         cap_multiplier: float = None,
+        utc_offset: int = 0,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """
@@ -733,6 +738,7 @@ class ClusterBuilder:
                 max_clusters=max_clusters,
                 max_lcoe=max_lcoe,
                 cap_multiplier=cap_multiplier,
+                utc_offset=utc_offset,
             )
             .assign(**kwargs)
             .rename_axis("ids")

--- a/powergenome/resource_clusters.py
+++ b/powergenome/resource_clusters.py
@@ -588,7 +588,7 @@ class ResourceGroup:
             df["profile"] = list(
                 np.roll(
                     self.profiles.read(columns=df.index.astype(str)).values.T,
-                    -utc_offset,
+                    utc_offset,
                 )
             )
             merge["means"].append("profile")

--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -360,8 +360,6 @@ def main():
                         + gen_clusters["Resource"]
                         + "_"
                         + gen_clusters["cluster"].astype(str)
-                        + "_"
-                        + gen_clusters["R_ID"].astype(str)
                     )
                     gens = calculate_partial_CES_values(
                         gen_clusters, fuels, _settings

--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -397,7 +397,7 @@ def main():
                 (
                     reduced_resource_profile,
                     reduced_load_profile,
-                    long_duration_storage,
+                    time_series_mapping,
                 ) = reduce_time_domain(gen_variability, load, _settings)
                 write_results_file(
                     df=reduced_load_profile,
@@ -411,11 +411,11 @@ def main():
                     file_name="Generators_variability.csv",
                     include_index=True,
                 )
-                if long_duration_storage is not None:
+                if time_series_mapping is not None:
                     write_results_file(
-                        df=long_duration_storage,
+                        df=time_series_mapping,
                         folder=case_folder,
-                        file_name="Long_Duration_Storage.csv",
+                        file_name="time_series_mapping.csv",
                         include_index=False,
                     )
 

--- a/powergenome/time_reduction.py
+++ b/powergenome/time_reduction.py
@@ -3,6 +3,7 @@
 from sklearn.cluster import KMeans
 from sklearn.preprocessing import minmax_scale
 import numpy as np
+import datetime
 import pandas as pd
 
 
@@ -157,8 +158,8 @@ def kmeans_time_clustering(
     # Create an empty list storing name of each data point
     EachClusterRepPoint = [None] * num_clusters
 
-    # creating a dataframe for storing long duration storage related data
-    long_duration_storage = pd.DataFrame(columns=["slot", "cluster"])
+    # creating a dataframe for storing the mapping between representative time period and the entire year
+    time_series_mapping = pd.DataFrame(columns=["slot", "cluster"])
 
     for k in range(num_clusters):
         # Number of points in kth cluster (i.e. label=0)
@@ -178,7 +179,7 @@ def kmeans_time_clustering(
 
         # Creating a list that matches each week to a representative week
         for j in range(EachClusterWeight[k]):
-            long_duration_storage = long_duration_storage.append(
+            time_series_mapping = time_series_mapping.append(
                 pd.DataFrame(
                     {
                         "slot": int(
@@ -192,7 +193,7 @@ def kmeans_time_clustering(
             )
 
     # appending the week representing peak load
-    long_duration_storage = long_duration_storage.append(
+    time_series_mapping = time_series_mapping.append(
         pd.DataFrame(
             {"slot": int(GroupingwithPeakLoad[0][1:]), "cluster": k + 2}, index=[0]
         ),
@@ -200,7 +201,15 @@ def kmeans_time_clustering(
     )
 
     # same CSV file that will be used in GenX
-    long_duration_storage = long_duration_storage.sort_values(by=["slot"])
+    time_series_mapping = time_series_mapping.sort_values(by=["slot"])
+    time_series_mapping = time_series_mapping.reset_index(drop=True)
+
+    #extract month corresponding to each time slot
+    time_series_mapping['Month']=0
+    for slot in time_series_mapping['slot']:
+        dayOfYear = days_in_group * slot
+        d = datetime.datetime.strptime('{} {}'.format(dayOfYear, 2011),'%j %Y')
+        time_series_mapping['Month'][slot-1] = d.month
 
     # Storing selected groupings in a new data frame with appropriate dimensions
     # (E.g. load in GW)
@@ -326,7 +335,7 @@ def kmeans_time_clustering(
             "AnnualGenScaleFactor": ScaleFactor,  # Scale factor used to adjust load output to match annual generation of original data
             "RMSE": RMSE,  # Root mean square error between full year data and modeled full year data (duration curves)
             "AnnualProfile": FullLengthOutputs,
-            "long_duration_storage": long_duration_storage,
+            "time_series_mapping": time_series_mapping,
         },
         EachClusterRepPoint,
         EachClusterWeight,

--- a/powergenome/transmission.py
+++ b/powergenome/transmission.py
@@ -93,6 +93,7 @@ def agg_transmission_constraints(
     if tc_joined.empty:
         logger.info(f"No transmission lines exist between model regions {combos}")
         tc_joined["Transmission Path Name"] = None
+        tc_joined.rename(columns=zone_num_map, inplace=True)
         return tc_joined.reset_index(drop=True)
 
     tc_joined["Network_lines"] = range(1, len(tc_joined) + 1)

--- a/powergenome/util.py
+++ b/powergenome/util.py
@@ -187,15 +187,6 @@ def download_save(url: str, save_path: Union[str, Path]):
     save_path.write_bytes(r.content)
 
 
-def shift_wrap_profiles(df, offset):
-    "Shift hours to a local offset and append first rows to end"
-
-    wrap_rows = df.iloc[:offset, :]
-
-    shifted_wrapped_df = pd.concat([df.iloc[offset:, :], wrap_rows], ignore_index=True)
-    return shifted_wrapped_df
-
-
 def update_dictionary(d: dict, u: dict) -> dict:
     """
     Update keys in an existing dictionary (d) with values from u

--- a/powergenome/util.py
+++ b/powergenome/util.py
@@ -57,7 +57,7 @@ def check_settings(settings: dict, pudl_engine: sa.engine) -> None:
         itertools.chain.from_iterable(settings["aeo_fuel_region_map"].values())
     )
 
-    for agg_region, ipm_regions in settings["region_aggregations"].items():
+    for agg_region, ipm_regions in (settings.get("region_aggregations") or {}).items():
         for ipm_region in ipm_regions:
             if ipm_region not in ipm_region_list:
                 s = f"""

--- a/powergenome/util.py
+++ b/powergenome/util.py
@@ -43,7 +43,7 @@ def check_settings(settings: dict, pudl_engine: sa.engine) -> None:
         Parameters and values from the YAML settings file.
     pudl_engine : sa.engine
         Connection to the PUDL sqlite database.
-    """    
+    """
 
     ipm_region_list = pd.read_sql_table("regions_entity_epaipm", pudl_engine)[
         "region_id_epaipm"
@@ -51,7 +51,7 @@ def check_settings(settings: dict, pudl_engine: sa.engine) -> None:
 
     cost_mult_regions = list(
         itertools.chain.from_iterable(settings["cost_multiplier_region_map"].values())
-    ) 
+    )
 
     aeo_fuel_regions = list(
         itertools.chain.from_iterable(settings["aeo_fuel_region_map"].values())
@@ -84,8 +84,26 @@ def check_settings(settings: dict, pudl_engine: sa.engine) -> None:
             """
             logger.warning(s)
 
-def init_pudl_connection(freq="YS"):
 
+def init_pudl_connection(
+    freq: str = "YS",
+) -> Tuple[sa.engine.base.Engine, pudl.output.pudltabl.PudlTabl]:
+    """Initiate a connection object to the sqlite PUDL database and create a pudl
+    object that can quickly access parts of the database.
+
+    Parameters
+    ----------
+    freq : str, optional
+        The time frequency that data should be averaged over in the `pudl_out` object,
+        by default "YS" (annual data).
+
+    Returns
+    -------
+    sa.Engine, pudl.pudltabl
+        A sqlalchemy engine for connecting to the PUDL database, and a pudl PudlTabl
+        object for quickly accessing parts of the database. `pudl_out` is used
+        to access unit heat rates.
+    """
     pudl_engine = sa.create_engine(
         SETTINGS["PUDL_DB"]
     )  # pudl.init.connect_db(SETTINGS)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="powergenome",
     packages=find_packages(),
-    version="0.3.4",
+    version="0.4.0",
     description="Extract PUDL data for use in power system models",
     author="Greg Schivley",
     entry_points={


### PR DESCRIPTION
The major update here was to use a new version of the PUDL database with ATB 2020 data. The tables `technology_costs_nrelatb` and `technology_heat_rates_nrelatb` now contain data from both the 2019 and 2020 releases of ATB. The tables were changed from wide to long format, and PG code was modified to access only necessary data (rather than loading the whole tables). Other related changes include:
- Changes to parameter names in the ATB tables, which should also be changed in the settings file.
  - `capex_mw` for `capex` (watch out so you don’t get capex_mwmwh from capex_mwh)
  - `fixed_o_m_mw` for `o_m_fixed_mw` (same for the `mwh` version if it shows up anywhere)
  - `variable_o_m_mwh` for `o_m_variable_mwh`
- Add the parameter `atb_data_year: 2020`

Other changes:
- Speed up filling null heat rates for existing generators.
- Modify nuclear fixed O&M to represent multi-unit, large single-unit (at least 900 MW), and small single-unit (less than 900 MW).
- Add the settings parameter `utc_offset`. Demand and renewable generation profiles are now shifted from UTC (how they're stored) based on this offset.
- Add month to long duration storage.
- Rename `long_duration_storage` to `time_series_mapping` in results of time domain reduction.
- Fill coal/nuclear unit ages where they are missing (median value for plant or 40 years as a heuristic).

