### PR TITLE
Split cogen into their own clusters

### DIFF
--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -364,7 +364,8 @@ def load_plant_region_map(
 
     if settings.get("plant_region_map_fn"):
         user_region_map_df = pd.read_csv(
-            Path(settings["input_folder"]) / settings["plant_region_map_fn"]
+            Path(settings["input_folder"]) / settings["plant_region_map_fn"],
+            dtype={"plant_id_eia": int}
         )
         assert (
             "region" in user_region_map_df.columns
@@ -1960,7 +1961,7 @@ def change_cogen_tech_names(df: pd.DataFrame, settings: dict) -> Tuple[pd.DataFr
     Tuple[pd.DataFrame, dict]
         The modified generation units and settings
     """
-
+    start_capacity = df[settings["capacity_col"]].sum()
     # Need a way to use PUDL to determine cogen units, just using an internal file for now
     if settings.get("cogen_units_fn"):
         cogen_units = pd.read_csv(
@@ -1970,7 +1971,7 @@ def change_cogen_tech_names(df: pd.DataFrame, settings: dict) -> Tuple[pd.DataFr
         cogen_ids = list(zip(cogen_units["plant_id_eia"], cogen_units["generator_id"]))
         df_ids = zip(df["plant_id_eia"], df["generator_id"])
         cogen_mask = [g in cogen_ids for g in df_ids]
-        df.loc[cogen_mask, "technology_description"] = df.loc[cogen_units.index, "technology_description"] + "_cogen"
+        df.loc[cogen_mask, "technology_description"] = df.loc[cogen_mask, "technology_description"] + "_cogen"
 
         cogen_techs = df.query("technology_description.str.contains('cogen')")["technology_description"].unique()
 
@@ -1981,6 +1982,8 @@ def change_cogen_tech_names(df: pd.DataFrame, settings: dict) -> Tuple[pd.DataFr
             for tech in cogen_techs:
                 settings["eia_atb_tech_map"][tech] = settings["eia_atb_tech_map"][tech.replace("_cogen", "")]
 
+    end_capacity = df[settings["capacity_col"]].sum()
+    assert start_capacity == end_capacity
     return df, settings
 
 


### PR DESCRIPTION
Separate cogen plants or units into a single cluster per technology/region. These units often operate differently from resources that only produce electricity. 