### PR TITLE
Add float format = "%g" to several csv output functions

### DIFF
--- a/bin/resource_group_stats.py
+++ b/bin/resource_group_stats.py
@@ -115,7 +115,7 @@ def main():
         )
         summary_fn = Path(SETTINGS["RESOURCE_GROUPS"]) / "resource_summary_stats.csv"
 
-    results_df.to_csv(summary_fn, index=False)
+    results_df.to_csv(summary_fn, index=False, float_format="%g")
 
 
 if __name__ == "__main__":

--- a/powergenome/eia_opendata.py
+++ b/powergenome/eia_opendata.py
@@ -52,7 +52,7 @@ def load_aeo_series(series_id: str, api_key: str, columns: list = None) -> pd.Da
                 "correct. The data returned from EIA's API is: \n"
                 f"{r.json()}"
             )
-        df.to_csv(data_dir / f"{series_id}.csv", index=False)
+        df.to_csv(data_dir / f"{series_id}.csv", index=False, float_format="%g")
     else:
         df = pd.read_csv(data_dir / f"{series_id}.csv")
 

--- a/powergenome/price_adjustment.py
+++ b/powergenome/price_adjustment.py
@@ -133,7 +133,7 @@ def load_cpi_data(reload_data: bool = False, **kwargs) -> pd.DataFrame:
             if k == "end_year":
                 end_year = v
         cpi_data = get_cpi_data(start_year, end_year)
-        cpi_data.to_csv(DATA_PATHS["cpi_data"], index=False)
+        cpi_data.to_csv(DATA_PATHS["cpi_data"], index=False, float_format="%g")
     else:
         cpi_data = pd.read_csv(DATA_PATHS["cpi_data"])
 

--- a/powergenome/run_powergenome_cli.py
+++ b/powergenome/run_powergenome_cli.py
@@ -211,7 +211,8 @@ def main():
         )
 
     if args.fuel and args.gens:
-        fuels.to_csv(out_folder / f"Fuels_data_{args.results_folder}.csv", index=False)
+        fuels.to_csv(out_folder / f"Fuels_data_{args.results_folder}.csv",
+                index=False, float_format="%g")
 
 
 if __name__ == "__main__":

--- a/powergenome/util.py
+++ b/powergenome/util.py
@@ -357,7 +357,7 @@ def write_results_file(df, folder, file_name, include_index=False):
 
     path_out = sub_folder / file_name
 
-    df.to_csv(path_out, index=include_index)
+    df.to_csv(path_out, index=include_index, float_format="%g")
 
 
 def write_case_settings_file(settings, folder, file_name):


### PR DESCRIPTION
I don't know how powergenome works and so someone should really check
this. I didn't add float_format to places where it already existed.
I also didn't add it to the pudl extraction since that seemed to be an
intermediate operation.