### PR TITLE
Check resource tags

### DIFF
--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -49,6 +49,8 @@ COL_ROUND_VALUES = {
     "Line_Loss_Percentage": 4,
 }
 
+RESOURCE_TAGS = ["THERM", "VRE", "MUST_RUN", "STOR", "FLEX", "HYDRO", "LDS"]
+
 
 def create_policy_req(settings: dict, col_str_match: str) -> pd.DataFrame:
     model_year = settings["model_year"]
@@ -924,3 +926,49 @@ def max_cap_req(settings: dict) -> pd.DataFrame:
         return max_cap_df
     else:
         return None
+
+
+def check_resource_tags(df: pd.DataFrame) -> pd.DataFrame:
+    """Check complete generators dataframe to make sure each resource is assigned one,
+    and only one, resource tag.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Resource clusters. Should have columns "technology" and "region" in addition
+        to the resource tag columns expected by GenX.
+
+    Returns
+    -------
+    pd.DataFrame
+        An unaltered version of the input dataframe.
+    """
+
+    if not (df[RESOURCE_TAGS].sum(axis=1) == 1).all():
+        for idx, row in df.iterrows():
+            num_tags = row[RESOURCE_TAGS].sum()
+            if num_tags == 0:
+                logger.warning(
+                    "\n*************************\n"
+                    f"The resource {row['technology']} in region {row['region']} does "
+                    "not have any assigned resource tags. Check the 'model_tag_values' and "
+                    "'regional_tag_values' parameters in your settings file to make sure"
+                    "it is assigned one resource tag type from this list:\n\n"
+                    f"{RESOURCE_TAGS}\n"
+                )
+            if num_tags > 1:
+                s = row[RESOURCE_TAGS]
+                tags = list(s[s == 1].index)
+                logger.warning(
+                    "\n*************************\n"
+                    f"The resource {row['technology']} in region {row['region']} is "
+                    f"assigned {num_tags} resource tags ({tags}). Check the 'model_tag_values'"
+                    " and 'regional_tag_values' parameters in your settings file to make"
+                    " sure it is assigned only one resource tag type from this list:\n\n"
+                    f"{RESOURCE_TAGS}\n"
+                )
+
+        raise ValueError(
+            "Use the warnings above to fix the resource tags in your settings file."
+        )
+    return df

--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -18,6 +18,7 @@ from powergenome.generators import (
 )
 from powergenome.GenX import (
     add_cap_res_network,
+    check_resource_tags,
     create_policy_req,
     create_regional_cap_res,
     fix_min_power_values,
@@ -276,7 +277,8 @@ def main():
                             gens[cols].fillna(0), _settings
                         )
                         .pipe(set_int_cols)
-                        .pipe(round_col_values),
+                        .pipe(round_col_values)
+                        .pipe(check_resource_tags),
                         folder=case_folder,
                         file_name="Generators_data.csv",
                         include_index=False,
@@ -321,7 +323,8 @@ def main():
                             gens[cols].fillna(0), _settings
                         )
                         .pipe(set_int_cols)
-                        .pipe(round_col_values),
+                        .pipe(round_col_values)
+                        .pipe(check_resource_tags),
                         folder=case_folder,
                         file_name="Generators_data.csv",
                         include_index=False,

--- a/tests/generation_test.py
+++ b/tests/generation_test.py
@@ -4,7 +4,9 @@ import sqlite3
 import os
 from pathlib import Path
 from powergenome.GenX import (
+    RESOURCE_TAGS,
     add_cap_res_network,
+    check_resource_tags,
     create_policy_req,
     create_regional_cap_res,
     max_cap_req,
@@ -519,3 +521,20 @@ def test_cap_req():
     assert set(settings["generator_columns"]) == set(settings["model_tag_names"])
     assert min_cap.isna().any().all() == False
     assert max_cap.isna().any().all() == False
+
+
+def test_check_resource_tags():
+    # Check something that should fail
+    cols = ["region", "technology"] + RESOURCE_TAGS
+    data = [pd.Series(["a", "b"] + [1] * len(RESOURCE_TAGS), index=cols)]
+    df = pd.DataFrame(data)
+
+    with pytest.raises(Exception):
+        check_resource_tags(df)
+
+    # Check something that should pass
+    cols = ["region", "technology"] + RESOURCE_TAGS
+    data = [pd.Series(["a", "b", 1] + [0] * (len(RESOURCE_TAGS) - 1), index=cols)]
+    df = pd.DataFrame(data)
+
+    check_resource_tags(df)


### PR DESCRIPTION
GenX only allows one resource tag (type) per resource. Add a check for the final generators DataFrame and test the check function.