### PR TITLE
Include reverse direction of user inputted transmission lines

### DIFF
--- a/powergenome/transmission.py
+++ b/powergenome/transmission.py
@@ -38,9 +38,17 @@ def agg_transmission_constraints(
             / settings["user_transmission_constraints_fn"]
         )
 
+        # user constraints are needed bidirectionaly
         transmission_constraints_table = pd.concat(
-            [transmission_constraints_table, user_tx_constraints]
+            [
+                transmission_constraints_table,
+                user_tx_constraints,
+                user_tx_constraints.rename(
+                    columns={"region_from": "region_to", "region_to": "region_from"}
+                ),
+            ]
         )
+
     # Settings has a dictionary of lists for regional aggregations. Need
     # to reverse this to use in a map method.
     region_agg_map = reverse_dict_of_lists(settings.get(settings_agg_key))


### PR DESCRIPTION
If a user inputs a transmission line where `(region_from, region_to)` is not in alphanumeric order, the indexing will not line up for `tc_table` and `reverse_tc`. This can be solved by duplicating and reversing the inputted transmission lines, and then appending those reversed tx lines to the `transmission_constraints_table`.