### PR TITLE
Define variables if there is not an emissions file.

### DIFF
--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -396,6 +396,9 @@ def main():
                 if _settings.get("emission_policies_fn"):
                     energy_share_req = create_policy_req(_settings, col_str_match="ESR")
                     co2_cap = create_policy_req(_settings, col_str_match="CO_2")
+                else:
+                    energy_share_req = None
+                    co2_cap = None
                 min_cap = min_cap_req(_settings)
                 max_cap = max_cap_req(_settings)
 


### PR DESCRIPTION
If there is not an emissions file, define `energy_share_req` and `co2_cap` to `None` to avoid a Name Error.