### PR TITLE
Sort load profiles

### DIFF
--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -230,6 +230,10 @@ def make_final_load_curves(
 
     final_load_curves = final_load_curves.astype(int)
 
+    # change order to match model regions
+    model_regions = settings.get("model_regions")
+    final_load_curves = final_load_curves[model_regions]
+
     return final_load_curves
 
 


### PR DESCRIPTION
GenX expects that the load profiles in `Load_data.csv` are sorted by zone. Specifically, it requires that "Load_MW_z1" is the first load profile column. `settings["model_regions"]` is already sorted by Python's `sorted()` function and will maintain the proper order.