### PR TITLE
Change sqlite prefix based on operating system

### DIFF
--- a/tests/generation_test.py
+++ b/tests/generation_test.py
@@ -82,12 +82,16 @@ logger.addHandler(handler)
 # pg_engine = sqlalchemy.create_engine(
 #     "sqlite:////" + str(DATA_PATHS["test_data"] / "pg_misc_tables.sqlite3")
 # )
-
+if os.name == "nt":
+    # if user is using a windows system
+    sql_prefix = "sqlite:///"
+else:
+    sql_prefix = "sqlite:////"
 pudl_engine, pudl_out, pg_engine = init_pudl_connection(
     start_year=2018,
     end_year=2020,
-    pudl_db="sqlite:////" + str(DATA_PATHS["test_data"] / "pudl_test_data.db"),
-    pg_db="sqlite:////" + str(DATA_PATHS["test_data"] / "pg_misc_tables.sqlite3"),
+    pudl_db=sql_prefix + str(DATA_PATHS["test_data"] / "pudl_test_data.db"),
+    pg_db=sql_prefix + str(DATA_PATHS["test_data"] / "pg_misc_tables.sqlite3"),
 )
 
 


### PR DESCRIPTION
To run unit tests on a windows machine, the prefix to the sqlite database path must be changed. On Windows systems, the prefix is `sqlite:///` (3 slashes). On Mac/Linux, the prefix in `sqlite:////` (four slashes). 

The variable `os.name` will be set tot `nt` if the code is being run on a Windows machine, so this can be used to change the prefix.