### PR TITLE
Search for region names in user_region_geodata_fn with the property "name"

### DIFF
--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -1374,48 +1374,6 @@ def add_genx_model_tags(df, settings):
     return df
 
 
-# def load_ipm_shapefile(settings, path=IPM_GEOJSON_PATH):
-#     """
-#     Load the shapefile of IPM regions
-
-#     Parameters
-#     ----------
-#     settings : dict
-#         User-defined parameters from a settings YAML file. This is where any region
-#         aggregations would be defined.
-
-#     Returns
-#     -------
-#     geodataframe
-#         Regions to use in the study with the matching geometry for each.
-#     """
-#     keep_regions, region_agg_map = regions_to_keep(settings)
-
-#     ipm_regions = gpd.read_file(IPM_GEOJSON_PATH)
-#     ipm_regions = ipm_regions.rename(columns={"IPM_Regions": "region"})
-
-#     if settings.get("user_region_geodata_fn"):
-#         logger.info("Appending user regions to IPM Regions")
-#         user_regions = gpd.read_file(
-#             Path(settings["input_folder"]) / settings["user_region_geodata_fn"]
-#         )
-#         if "region" not in user_regions.columns:
-#             raise KeyError(
-#                 "The user supplied region geodata file does not include the "
-#                 "property 'region' for any of the region polygons! User region "
-#                 "geodata can not be appropriately mapped to model regions."
-#             )
-#         user_regions = user_regions.to_crs(ipm_regions.crs)
-#         ipm_regions = ipm_regions.append(user_regions)
-
-#     model_regions_gdf = ipm_regions.loc[ipm_regions["region"].isin(keep_regions)]
-#     model_regions_gdf = map_agg_region_names(
-#         model_regions_gdf, region_agg_map, "region", "model_region"
-#     ).reset_index(drop=True)
-
-#     return model_regions_gdf
-
-
 def download_860m(settings: dict) -> pd.ExcelFile:
     """Load the entire 860m file into memory as an ExcelFile object.
 

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -1398,6 +1398,19 @@ def load_ipm_shapefile(settings, path=IPM_GEOJSON_PATH):
         user_regions = gpd.read_file(
             Path(settings["input_folder"]) / settings["user_region_geodata_fn"]
         )
+        try:
+            # The rest of PowerGenome uses the column "IPM_Region" for the name of
+            # the region. Eventually, it may be worth it to go through the model
+            # and rename this column to something more generic.
+            user_regions = user_regions.rename(
+                columns={"name": "IPM_Region"}, errors="raise"
+            )
+        except KeyError:
+            logger.warning(
+                "The user supplied region geodata file does not include the "
+                "property 'name' for any of the region polygons! User region "
+                "geodata can not be appropriately mapped to model regions."
+            )
         user_regions = user_regions.to_crs(ipm_regions.crs)
         ipm_regions = ipm_regions.append(user_regions)
     # ipm_regions = gpd.read_file(IPM_SHAPEFILE_PATH)

--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -12,7 +12,6 @@ import powergenome
 from powergenome.fuels import fuel_cost_table
 from powergenome.generators import (
     GeneratorClusters,
-    load_ipm_shapefile,
     add_fuel_labels,
     add_genx_model_tags,
 )
@@ -51,6 +50,7 @@ from powergenome.util import (
     update_dictionary,
     write_case_settings_file,
     write_results_file,
+    load_ipm_shapefile,
 )
 
 if not sys.warnoptions:


### PR DESCRIPTION
User inputted regions require the property "IPM_Region" to map to model regions, which is a bit of a misnomer. I allowed the name of this property to be "name" and have PowerGenome rename it internally to "IPM_Region". The longer and more robust fix would be to change every instance of "IPM_Region" to something more generic. 

Feel free to adjust.