### PR TITLE
Allow users to specify load source.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -29,6 +29,11 @@
             "affiliation": "Princeton University"
         },
         {
+            "name": "Braden Pecora",
+            "affiliation": "IdeaSmiths LLC",
+            "orcid": "0000-0003-3555-3708"
+        },
+        {
             "name": "Jesse D. Jenkins",
             "affiliation": "Princeton University",
             "orcid": "0000-0002-9670-7793"

--- a/powergenome/eia_opendata.py
+++ b/powergenome/eia_opendata.py
@@ -258,7 +258,10 @@ def add_user_fuel_prices(settings: dict, df: pd.DataFrame = None) -> pd.DataFram
 
 
 def get_aeo_load(
-    region: str, aeo_year: Union[str, numeric], scenario_series: str
+    region: str,
+    aeo_year: Union[str, numeric],
+    scenario_series: str,
+    sector: str = "ELEP",
 ) -> pd.DataFrame:
     """Find the electricity demand in a single AEO region. Use EIA API if data has not
     been previously saved.
@@ -295,7 +298,7 @@ def get_aeo_load(
     API_KEY = SETTINGS["EIA_API_KEY"]
 
     SERIES_ID = (
-        f"AEO.{aeo_year}.{scenario_series}.CNSM_NA_ELEP_NA_ELC_NA_{region}_BLNKWH.A"
+        f"AEO.{aeo_year}.{scenario_series}.CNSM_NA_{sector}_NA_ELC_NA_{region}_BLNKWH.A"
     )
 
     df = load_aeo_series(SERIES_ID, API_KEY, columns=["year", "demand"])

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -181,6 +181,9 @@ def load_usr_demand_profiles(settings):
     if len(hourly_load_profiles) == 8784:
         remove_feb_29(hourly_load_profiles)
 
+    hourly_load_profiles.index.name = "time_index"
+    hourly_load_profiles.index = hourly_load_profiles.index + 1
+
     return hourly_load_profiles
 
 

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -482,7 +482,9 @@ def load_usr_demand_profiles(settings):
             remove_feb_29(hourly_load_profiles)
 
         hourly_load_profiles.index.name = "time_index"
-        hourly_load_profiles.index = hourly_load_profiles.index + 1
+        hourly_load_profiles.index = pd.RangeIndex(
+            start=1, stop=len(hourly_load_profiles) + 1, step=1
+        )
 
         regional_load_sources = settings.get("regional_load_source")
         if regional_load_sources is not None:
@@ -551,6 +553,17 @@ def make_final_load_curves(
         for load_source, load_table in load_sources.items()
     ]
     load_curves_before_dr.append(user_load_curves)
+    if not all(
+        [
+            len(load_curves_before_dr[0].index.intersection(df.index))
+            == load_curves_before_dr[0].shape[0]
+            for df in load_curves_before_dr
+            if df is not None
+        ]
+    ):
+        raise ValueError(
+            "One or more of your load curve data sources does not have a matching time index."
+        )
 
     try:
         load_curves_before_dr = pd.concat(load_curves_before_dr, axis=1)

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -48,7 +48,10 @@ def filter_load_by_region(load_source):  # "decorator factory"
                 if load_source == regional_load_sources:
                     # if only one load profile sources are specified, use for all regions
                     regions = settings.get("model_regions")
-                elif load_source in regional_load_sources.keys():
+                elif (
+                    isinstance(regional_load_sources, dict)
+                    and load_source in regional_load_sources.keys()
+                ):
                     # if multiple load profiles sources are specified, find the proper regions
                     regions = regional_load_sources.get(load_source)
 

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -25,8 +25,8 @@ def filter_load_by_region(load_source):  # "decorator factory"
     If settings["regional_load_source"] exists and settings["regional_load_source"][load_source]
     is null, return None.
 
-    If settings["regional_load_source"] DNE, return the load profile if the load_source is FERC,
-    else return None. This makes FERC the default load type/source.
+    If settings["regional_load_source"] DNE, return the load profile if the load_source is EFS,
+    else return None. This makes EFS the default load type/source.
     """
 
     def decorator(func):
@@ -61,7 +61,7 @@ def filter_load_by_region(load_source):  # "decorator factory"
                     load_profile = None
             else:
                 load_profile = None
-                if load_source == "FERC":
+                if load_source == "EFS":
                     load_profile = func(*args, **kwargs)
 
             return load_profile
@@ -448,14 +448,14 @@ def make_final_load_curves(
     if load_sources is None:
         s = """
         *****************************
-        Regional load data sources have not been specified. Defaulting to FERC load data.
+        Regional load data sources have not been specified. Defaulting to EFS load data.
         Check you settings file, and please specify the preferred source for load data
         (FERC, EFS, USER) either for each region or for the entire system with the setting
         "regional_load_source".
         *****************************
         """
         logger.warning(s)
-        load_sources = {"FERC": "load_curves_ferc", "EFS": "load_curves_nrel_efs"}
+        load_sources = {"EFS": "load_curves_nrel_efs"}
 
     # `filter_load_by_region` is a decorator factory that generates a decorator
     # when given the parameter `load_source`. This decorator creates a wrapper

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -5,9 +5,11 @@ Hourly demand profiles
 import logging
 from inspect import signature
 from pathlib import Path
+from typing import Dict, List
 
 import numpy as np
 import pandas as pd
+import sqlalchemy as sa
 
 from powergenome.eia_opendata import get_aeo_load
 from powergenome.external_data import make_demand_response_profiles
@@ -70,10 +72,10 @@ def filter_load_by_region(load_source):  # "decorator factory"
 
 
 def make_load_curves(
-    pg_engine,
-    settings,
-    pg_table="load_curves_ferc",
-    settings_agg_key="region_aggregations",
+    pg_engine: sa.engine.base.Engine,
+    settings: dict,
+    pg_table: str = "load_curves_nrel_efs",
+    settings_agg_key: str = "region_aggregations",
 ):
     # IPM regions to keep. Regions not in this list will be dropped from the
     # dataframe
@@ -82,32 +84,73 @@ def make_load_curves(
     # I'd rather use a sql query and only pull the regions of interest but
     # sqlalchemy doesn't allow table names to be parameterized.
     logger.info("Loading load curves from PUDL")
-    load_curves = pd.read_sql_table(
-        pg_table, pg_engine, columns=["region_id_epaipm", "time_index", "load_mw"]
-    )
-
-    load_curves = load_curves.loc[load_curves.region_id_epaipm.isin(keep_regions)]
+    inst = sa.inspect(pg_engine)
+    if not inst.has_table(pg_table):
+        raise KeyError(
+            f"There is no load curves table with the name {pg_table} in the 'PG_DB' "
+            "database specified in your .env file."
+        )
+    table_cols = [c["name"] for c in inst.get_columns(pg_table)]
+    if "sector" in table_cols or "subsector" in table_cols:
+        if settings.get("electrification_stock_fn") and settings.get(
+            "electrification_scenario"
+        ):
+            # This is a default list of sector/subsectors that are considered "base" demand
+            # and are not affected by stock levels of electric technologies (e.g. EVs and heat pumps)
+            # NOTE: This should be parameratized so it can be changed by the user, especially
+            # if load data is from a source other than NREL EFS
+            base_sector_subsectors = [
+                ("commercial", "other"),
+                ("residential", "other"),
+                ("residential", "clothes and dish washing/drying"),
+                ("industrial", "machine drives"),
+                ("industrial", "process heat"),
+                ("industrial", "other"),
+            ]
+            s = f"""
+                    SELECT year, region, time_index, sector, sum(load_mw) as load_mw
+                    FROM {pg_table}
+                    WHERE region in ({','.join(['?']*len(keep_regions))})
+                    AND
+                    ({' OR '.join(["(sector=? and subsector=?)"]*len(base_sector_subsectors))})
+                    GROUP BY year, region, sector, time_index
+                    """
+            params = keep_regions + [
+                item for sublist in base_sector_subsectors for item in sublist
+            ]
+            load_curves = pd.read_sql_query(sql=s, con=pg_engine, params=params)
+        else:
+            s = f"""
+                    SELECT year, region, time_index, sector, sum(load_mw) as load_mw
+                    FROM {pg_table}
+                    WHERE region in ({','.join(['?']*len(keep_regions))})
+                    GROUP BY year, region, sector, time_index
+                    """
+            params = keep_regions
+            load_curves = pd.read_sql_query(sql=s, con=pg_engine, params=params)
+    else:
+        # With no sector or subsector columns, assume that table has total load in each hour
+        s = f"""
+            SELECT year, region, time_index, load_mw
+            FROM {pg_table}
+            WHERE region in ({','.join(['?']*len(keep_regions))})
+            """
+        params = keep_regions
+        load_curves = pd.read_sql_query(sql=s, con=pg_engine, params=params)
 
     # Increase demand to account for load growth
     load_curves = add_load_growth(load_curves, settings)
 
-    # Set a new column "region" to the old column values. Then replace values for any
-    # regions that are being aggregated
-    load_curves.loc[:, "region"] = load_curves.loc[:, "region_id_epaipm"]
-
     load_curves.loc[
-        load_curves.region_id_epaipm.isin(region_agg_map.keys()), "region"
-    ] = load_curves.loc[
-        load_curves.region_id_epaipm.isin(region_agg_map.keys()), "region_id_epaipm"
-    ].map(
-        region_agg_map
-    )
+        load_curves.region.isin(region_agg_map), "region"
+    ] = load_curves.region.map(region_agg_map)
 
     logger.info("Aggregating load curves in grouped regions")
-    load_curves_agg = load_curves.groupby(["region", "time_index"]).sum()
+    load_curves_agg = load_curves.groupby(["region", "time_index"])["load_mw"].sum()
 
     lc_wide = load_curves_agg.unstack(level=0)
-    lc_wide.columns = lc_wide.columns.droplevel()
+    if lc_wide.columns.nlevels > 1:
+        lc_wide.columns = lc_wide.columns.droplevel()
 
     if len(lc_wide) == 8784:
         lc_wide = remove_feb_29(lc_wide)
@@ -127,67 +170,196 @@ def add_load_growth(load_curves: pd.DataFrame, settings: dict) -> pd.DataFrame:
     keep_regions, region_agg_map = regions_to_keep(settings)
     hist_region_map = reverse_dict_of_lists(settings["historical_load_region_maps"])
     future_region_map = reverse_dict_of_lists(settings["future_load_region_map"])
+    load_curves["demand_year"] = load_curves["year"]
+    aeo_sector_map = settings.get("aeo_sector_map")
+    if not settings.get("aeo_sector_map"):
+        aeo_sector_map = {
+            "commercial": "COMM",
+            "industrial": "IDAL",
+            "residential": "RESD",
+            "transportation": "TRN",
+        }
+    if "sector" in load_curves.columns:
+        load_sectors = set(load_curves.sector.unique())
+        aeo_sectors = set(aeo_sector_map)
+        if not all([s in load_sectors for s in aeo_sectors]):
+            missing_sectors = list(load_sectors - aeo_sectors)
+            logger.warning(
+                "*********************\n"
+                f"The load sectors {missing_sectors} are in your load data but are not "
+                "mapped to EIA AEO sectors. The hourly values for these sectors will not "
+                "be changed unless you added a growth rate for this sector to all regions "
+                "in the settings parameter 'alt_growth_rate'."
+                "*********************\n"
+            )
 
-    hist_demand_start = {
-        ipm_region: get_aeo_load(
-            region=hist_region_map[ipm_region], aeo_year=2014, scenario_series="REF2014"
+    outer_list = []
+    for year, df in load_curves.groupby("year"):
+        if year < 2019:
+            old_aeo_list = []
+            # Growth rate up through 2018. New EMM regions were available in AEO2020,
+            # covering through the year 2019
+            # This is probably slow but serves as a good start
+            if "sector" in df.columns:
+                for sector, _df in df.groupby("sector"):
+                    hist_demand_start = {
+                        ipm_region: get_aeo_load(
+                            region=hist_region_map[ipm_region],
+                            aeo_year=year + 2,
+                            scenario_series=f"REF{year+2}",
+                            sector=aeo_sector_map[sector],
+                        )
+                        .set_index("year")
+                        .loc[year, "demand"]
+                        for ipm_region in keep_regions
+                    }
+                    hist_demand_end = {
+                        ipm_region: get_aeo_load(
+                            region=hist_region_map[ipm_region],
+                            aeo_year=2019,
+                            scenario_series="REF2019",
+                            sector=aeo_sector_map[sector],
+                        )
+                        .set_index("year")
+                        .loc[2018, "demand"]
+                        for ipm_region in keep_regions
+                    }
+                    growth_factor = {
+                        ipm_region: hist_demand_end[ipm_region]
+                        / hist_demand_start[ipm_region]
+                        for ipm_region in keep_regions
+                    }
+
+                    years_growth = 2019 - year
+                    for region, rate in (settings.get("alt_growth_rate") or {}).items():
+                        if isinstance(rate, dict) and rate.get(sector):
+                            growth_factor[region] = (1 + rate["sector"]) ** years_growth
+                    for region in keep_regions:
+                        _df.loc[_df["region"] == region, "load_mw"] *= growth_factor[
+                            region
+                        ]
+                    old_aeo_list.append(_df)
+
+            else:
+                hist_demand_start = {
+                    ipm_region: get_aeo_load(
+                        region=hist_region_map[ipm_region],
+                        aeo_year=year + 2,
+                        scenario_series=f"REF{year+2}",
+                    )
+                    .set_index("year")
+                    .loc[year, "demand"]
+                    for ipm_region in keep_regions
+                }
+                hist_demand_end = {
+                    ipm_region: get_aeo_load(
+                        region=hist_region_map[ipm_region],
+                        aeo_year=2019,
+                        scenario_series="REF2019",
+                    )
+                    .set_index("year")
+                    .loc[2019, "demand"]
+                    for ipm_region in keep_regions
+                }
+                growth_factor = {
+                    ipm_region: hist_demand_end[ipm_region]
+                    / hist_demand_start[ipm_region]
+                    for ipm_region in keep_regions
+                }
+
+                years_growth = 2019 - year
+                for region, rate in (settings.get("alt_growth_rate") or {}).items():
+                    if isinstance(rate, float):
+                        growth_factor[region] = (1 + rate) ** years_growth
+                for region in keep_regions:
+                    df.loc[df["region"] == region, "load_mw"] *= growth_factor[region]
+                old_aeo_list.append(df)
+
+            load_curves = pd.concat(old_aeo_list, ignore_index=True)
+
+            # Reset the "year" variable to 2019, which is where load data should be adjusted
+            # to at this point.
+            year = 2019
+
+        growth_scenario = settings.get("growth_scenario", "REF2020")
+        load_aeo_year = settings.get("load_eia_aeo_year") or settings.get(
+            "eia_aeo_year", 2020
         )
-        .set_index("year")
-        .loc[2012, "demand"]
-        for ipm_region in keep_regions
-    }
-    hist_demand_end = {
-        ipm_region: get_aeo_load(
-            region=hist_region_map[ipm_region], aeo_year=2019, scenario_series="REF2019"
-        )
-        .set_index("year")
-        .loc[2018, "demand"]
-        for ipm_region in keep_regions
-    }
 
-    growth_scenario = settings.get("growth_scenario", "REF2020")
-    load_aeo_year = settings.get("load_eia_aeo_year") or settings.get(
-        "eia_aeo_year", 2020
-    )
-    load_growth_dict = {
-        ipm_region: get_aeo_load(
-            region=future_region_map[ipm_region],
-            aeo_year=load_aeo_year,
-            scenario_series=growth_scenario,
-        ).set_index("year")
-        for ipm_region in keep_regions
-    }
+        df_list = []
+        if "sector" in df.columns:
+            for sector, _df in df.groupby("sector"):
+                load_growth_dict = {
+                    ipm_region: get_aeo_load(
+                        region=future_region_map[ipm_region],
+                        aeo_year=load_aeo_year,
+                        scenario_series=growth_scenario,
+                        sector=aeo_sector_map[sector],
+                    ).set_index("year")
+                    for ipm_region in keep_regions
+                }
 
-    load_growth_start_map = {
-        ipm_region: _df.loc[
-            settings.get("regular_load_growth_start_year", 2019), "demand"
-        ]
-        for ipm_region, _df in load_growth_dict.items()
-    }
+                load_growth_start_map = {
+                    ipm_region: _df.loc[year, "demand"]
+                    for ipm_region, _df in load_growth_dict.items()
+                }
 
-    load_growth_end_map = {
-        ipm_region: _df.loc[settings["model_year"], "demand"]
-        for ipm_region, _df in load_growth_dict.items()
-    }
+                load_growth_end_map = {
+                    ipm_region: _df.loc[settings["model_year"], "demand"]
+                    for ipm_region, _df in load_growth_dict.items()
+                }
 
-    future_growth_factor = {
-        ipm_region: load_growth_end_map[ipm_region] / load_growth_start_map[ipm_region]
-        for ipm_region in keep_regions
-    }
-    hist_growth_factor = {
-        ipm_region: hist_demand_end[ipm_region] / hist_demand_start[ipm_region]
-        for ipm_region in keep_regions
-    }
+                growth_factor = {
+                    ipm_region: load_growth_end_map[ipm_region]
+                    / load_growth_start_map[ipm_region]
+                    for ipm_region in keep_regions
+                }
 
-    years_growth = settings["model_year"] - settings["regular_load_growth_start_year"]
+                years_growth = settings["model_year"] - year
+                for region, rate in (settings.get("alt_growth_rate") or {}).items():
+                    if isinstance(rate, dict) and rate.get(sector):
+                        growth_factor[region] = (1 + rate["sector"]) ** years_growth
+                for region in keep_regions:
+                    _df.loc[_df["region"] == region, "load_mw"] *= growth_factor[region]
+                df_list.append(_df)
+        else:
+            load_growth_dict = {
+                ipm_region: get_aeo_load(
+                    region=future_region_map[ipm_region],
+                    aeo_year=load_aeo_year,
+                    scenario_series=growth_scenario,
+                ).set_index("year")
+                for ipm_region in keep_regions
+            }
 
-    for region, rate in (settings.get("alt_growth_rate") or {}).items():
-        future_growth_factor[region] = (1 + rate) ** years_growth
+            load_growth_start_map = {
+                ipm_region: _df.loc[year, "demand"]
+                for ipm_region, _df in load_growth_dict.items()
+            }
 
-    for region in keep_regions:
-        load_curves.loc[load_curves["region_id_epaipm"] == region, "load_mw"] *= (
-            hist_growth_factor[region] * future_growth_factor[region]
-        )
+            load_growth_end_map = {
+                ipm_region: _df.loc[settings["model_year"], "demand"]
+                for ipm_region, _df in load_growth_dict.items()
+            }
+
+            growth_factor = {
+                ipm_region: load_growth_end_map[ipm_region]
+                / load_growth_start_map[ipm_region]
+                for ipm_region in keep_regions
+            }
+
+            years_growth = settings["model_year"] - year
+            for region, rate in (settings.get("alt_growth_rate") or {}).items():
+                if isinstance(rate, float):
+                    growth_factor[region] = (1 + rate) ** years_growth
+            for region in keep_regions:
+                df.loc[df["region"] == region, "load_mw"] *= growth_factor[region]
+            df_list.append(df)
+
+        annual_load = pd.concat(df_list, ignore_index=True)
+        outer_list.append(annual_load)
+
+    load_curves = pd.concat(outer_list, ignore_index=True)
 
     return load_curves
 
@@ -265,7 +437,7 @@ def load_usr_demand_profiles(settings):
 def make_final_load_curves(
     pg_engine,
     settings,
-    pudl_table="load_curves_ferc",
+    pudl_table="load_curves_nrel_efs",
     settings_agg_key="region_aggregations",
 ):
 
@@ -277,13 +449,13 @@ def make_final_load_curves(
         s = """
         *****************************
         Regional load data sources have not been specified. Defaulting to FERC load data.
-        Check you settings file, and please specify the preferred source for load data 
+        Check you settings file, and please specify the preferred source for load data
         (FERC, EFS, USER) either for each region or for the entire system with the setting
         "regional_load_source".
         *****************************
         """
         logger.warning(s)
-        load_sources = {"FERC": "load_curves_ferc"}
+        load_sources = {"FERC": "load_curves_ferc", "EFS": "load_curves_nrel_efs"}
 
     # `filter_load_by_region` is a decorator factory that generates a decorator
     # when given the parameter `load_source`. This decorator creates a wrapper

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -265,31 +265,30 @@ def add_load_growth(load_curves: pd.DataFrame, settings: dict) -> pd.DataFrame:
             if "sector" in df.columns:
                 for sector, _df in df.groupby("sector"):
                     hist_demand_start = {
-                        ipm_region: get_aeo_load(
-                            region=hist_region_map[ipm_region],
+                        region: get_aeo_load(
+                            region=hist_region_map[region],
                             aeo_year=year + 2,
                             scenario_series=f"REF{year+2}",
                             sector=aeo_sector_map[sector],
                         )
                         .set_index("year")
                         .loc[year, "demand"]
-                        for ipm_region in keep_regions
+                        for region in keep_regions
                     }
                     hist_demand_end = {
-                        ipm_region: get_aeo_load(
-                            region=hist_region_map[ipm_region],
+                        region: get_aeo_load(
+                            region=hist_region_map[region],
                             aeo_year=2019,
                             scenario_series="REF2019",
                             sector=aeo_sector_map[sector],
                         )
                         .set_index("year")
                         .loc[2019, "demand"]
-                        for ipm_region in keep_regions
+                        for region in keep_regions
                     }
                     growth_factor = {
-                        ipm_region: hist_demand_end[ipm_region]
-                        / hist_demand_start[ipm_region]
-                        for ipm_region in keep_regions
+                        region: hist_demand_end[region] / hist_demand_start[region]
+                        for region in keep_regions
                     }
 
                     years_growth = 2019 - year
@@ -304,29 +303,28 @@ def add_load_growth(load_curves: pd.DataFrame, settings: dict) -> pd.DataFrame:
 
             else:
                 hist_demand_start = {
-                    ipm_region: get_aeo_load(
-                        region=hist_region_map[ipm_region],
+                    region: get_aeo_load(
+                        region=hist_region_map[region],
                         aeo_year=year + 2,
                         scenario_series=f"REF{year+2}",
                     )
                     .set_index("year")
                     .loc[year, "demand"]
-                    for ipm_region in keep_regions
+                    for region in keep_regions
                 }
                 hist_demand_end = {
-                    ipm_region: get_aeo_load(
-                        region=hist_region_map[ipm_region],
+                    region: get_aeo_load(
+                        region=hist_region_map[region],
                         aeo_year=2019,
                         scenario_series="REF2019",
                     )
                     .set_index("year")
                     .loc[2019, "demand"]
-                    for ipm_region in keep_regions
+                    for region in keep_regions
                 }
                 growth_factor = {
-                    ipm_region: hist_demand_end[ipm_region]
-                    / hist_demand_start[ipm_region]
-                    for ipm_region in keep_regions
+                    region: hist_demand_end[region] / hist_demand_start[region]
+                    for region in keep_regions
                 }
 
                 years_growth = 2019 - year
@@ -352,29 +350,28 @@ def add_load_growth(load_curves: pd.DataFrame, settings: dict) -> pd.DataFrame:
         if "sector" in df.columns:
             for sector, _df in df.groupby("sector"):
                 load_growth_dict = {
-                    ipm_region: get_aeo_load(
-                        region=future_region_map[ipm_region],
+                    region: get_aeo_load(
+                        region=future_region_map[region],
                         aeo_year=load_aeo_year,
                         scenario_series=growth_scenario,
                         sector=aeo_sector_map[sector],
                     ).set_index("year")
-                    for ipm_region in keep_regions
+                    for region in keep_regions
                 }
 
                 load_growth_start_map = {
-                    ipm_region: _df.loc[year, "demand"]
-                    for ipm_region, _df in load_growth_dict.items()
+                    region: _df.loc[year, "demand"]
+                    for region, _df in load_growth_dict.items()
                 }
 
                 load_growth_end_map = {
-                    ipm_region: _df.loc[settings["model_year"], "demand"]
-                    for ipm_region, _df in load_growth_dict.items()
+                    region: _df.loc[settings["model_year"], "demand"]
+                    for region, _df in load_growth_dict.items()
                 }
 
                 growth_factor = {
-                    ipm_region: load_growth_end_map[ipm_region]
-                    / load_growth_start_map[ipm_region]
-                    for ipm_region in keep_regions
+                    region: load_growth_end_map[region] / load_growth_start_map[region]
+                    for region in keep_regions
                 }
 
                 years_growth = settings["model_year"] - year
@@ -386,28 +383,27 @@ def add_load_growth(load_curves: pd.DataFrame, settings: dict) -> pd.DataFrame:
                 df_list.append(_df)
         else:
             load_growth_dict = {
-                ipm_region: get_aeo_load(
-                    region=future_region_map[ipm_region],
+                region: get_aeo_load(
+                    region=future_region_map[region],
                     aeo_year=load_aeo_year,
                     scenario_series=growth_scenario,
                 ).set_index("year")
-                for ipm_region in keep_regions
+                for region in keep_regions
             }
 
             load_growth_start_map = {
-                ipm_region: _df.loc[year, "demand"]
-                for ipm_region, _df in load_growth_dict.items()
+                region: _df.loc[year, "demand"]
+                for region, _df in load_growth_dict.items()
             }
 
             load_growth_end_map = {
-                ipm_region: _df.loc[settings["model_year"], "demand"]
-                for ipm_region, _df in load_growth_dict.items()
+                region: _df.loc[settings["model_year"], "demand"]
+                for region, _df in load_growth_dict.items()
             }
 
             growth_factor = {
-                ipm_region: load_growth_end_map[ipm_region]
-                / load_growth_start_map[ipm_region]
-                for ipm_region in keep_regions
+                region: load_growth_end_map[region] / load_growth_start_map[region]
+                for region in keep_regions
             }
 
             years_growth = settings["model_year"] - year

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -485,6 +485,11 @@ def load_usr_demand_profiles(settings):
         regional_load_sources = settings.get("regional_load_source")
         if regional_load_sources is not None:
             cols = regional_load_sources.get("USER")
+            if not all([col in hourly_load_profiles.columns for col in cols]):
+                raise KeyError(
+                    f"One or more of the regions {cols} is not included in your "
+                    f"user-supplied load curves file {regional_load_fn}."
+                )
             hourly_load_profiles = hourly_load_profiles.reindex(columns=cols)
 
         return hourly_load_profiles

--- a/powergenome/util.py
+++ b/powergenome/util.py
@@ -596,9 +596,7 @@ def find_centroid(gdf):
     return centroid
 
 
-def regions_to_keep(
-    settings: dict, ipm_only=False, user_only=False
-) -> Tuple[list, dict]:
+def regions_to_keep(settings: dict) -> Tuple[list, dict]:
     """Create a list of all IPM regions that are used in the model, either as single
     regions or as part of a user-defined model region. Also includes the aggregate
     regions defined by user.
@@ -608,9 +606,6 @@ def regions_to_keep(
     settings : dict
         User-defined parameters from a settings YAML file with keys "model_regions" and
         "region_aggregations".
-    ipm_only : binary
-        Returned regions are only IPM regions if True. Other regions (custom user regions)
-        are not included.
 
     Returns
     -------
@@ -626,29 +621,6 @@ def regions_to_keep(
         for x in settings["model_regions"] + list(region_agg_map)
         if x not in region_agg_map.values()
     ]
-
-    # consider `if settings.get("user_region_geodata_fn") is not None:` around this block?
-    if ipm_only and user_only:
-        logger.warning(
-            "Both `ipm_only` and `user_only` are set to True. "
-            "This is likely a bug in the code. Returning all model regions."
-        )
-    elif ipm_only or user_only:
-        # there is probably a better way to store this somewhere rather than read the file
-        # each time, which could save a few seconds.
-        ipm_regions = gpd.read_file(IPM_GEOJSON_PATH, ignore_geometry=True)[
-            "IPM_Region"
-        ].to_list()
-        if ipm_only:
-            regions_whitelist = ipm_regions
-        elif user_only:
-            regions_whitelist = set(settings.get("model_regions")) - set(ipm_regions)
-
-        keep_regions = [x for x in keep_regions if x in regions_whitelist]
-        region_agg_map = {
-            k: v for k, v in region_agg_map.items() if k in regions_whitelist
-        }
-
     return keep_regions, region_agg_map
 
 

--- a/tests/generation_test.py
+++ b/tests/generation_test.py
@@ -309,12 +309,27 @@ def test_demand_curve(test_settings):
     make_load_curves(pg_engine, test_settings)
 
 
+def test_alt_table_load_sources(CA_AZ_settings):
+    # Test with a single non-default load table
+    CA_AZ_settings["load_source_table_name"] = {
+        # "EFS": "load_curves_nrel_efs",
+        "FERC": "load_curves_ferc",
+    }
+    CA_AZ_settings["regional_load_source"] = "FERC"
+    make_final_load_curves(pg_engine, CA_AZ_settings)
+
+
 def test_combined_load_sources(CA_AZ_settings):
+    # Test with a combination of user and database load sources
     CA_AZ_settings["regional_load_fn"] = "test_regional_load_profiles.csv"
     CA_AZ_settings["load_source_table_name"] = {"EFS": "load_curves_nrel_efs"}
     CA_AZ_settings["regional_load_source"] = {
         "USER": ["CA_N", "CA_S"],
         "EFS": ["WECC_AZ"],
+    }
+    CA_AZ_settings["load_source_table_name"] = {
+        "EFS": "load_curves_nrel_efs",
+        "FERC": "load_curves_ferc",
     }
     CA_AZ_settings["electrification"] = "reference"
     make_final_load_curves(pg_engine, CA_AZ_settings)

--- a/tests/generation_test.py
+++ b/tests/generation_test.py
@@ -309,6 +309,17 @@ def test_demand_curve(test_settings):
     make_load_curves(pg_engine, test_settings)
 
 
+def test_combined_load_sources(CA_AZ_settings):
+    CA_AZ_settings["regional_load_fn"] = "test_regional_load_profiles.csv"
+    CA_AZ_settings["load_source_table_name"] = {"EFS": "load_curves_nrel_efs"}
+    CA_AZ_settings["regional_load_source"] = {
+        "USER": ["CA_N", "CA_S"],
+        "EFS": ["WECC_AZ"],
+    }
+    CA_AZ_settings["electrification"] = "reference"
+    make_final_load_curves(pg_engine, CA_AZ_settings)
+
+
 def test_check_settings(test_settings):
     check_settings(test_settings, pg_engine)
 


### PR DESCRIPTION
This fork allows users to specify the data source by region for each load profile.

The option `regional_load_source` maps load sources to regions.
```yaml
regional_load_source:
    USER: ["region_a", "region_b"]
    FERC: ["region_c", "region_d"]
```

The option `load_source_table` defines the SQL table from which to grab data.
```yaml
load_source_table:
    FERC: "load_curves_ferc"
```

The `regional_load_source` `USER` grabs data from `regional_load_fn`.