### PR TITLE
Conditional to avoid error if "USER" is the only specified load source.

### DIFF
--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -511,7 +511,10 @@ def load_usr_demand_profiles(settings):
 
         regional_load_sources = settings.get("regional_load_source")
         if regional_load_sources is not None:
-            cols = regional_load_sources.get("USER")
+            if regional_load_sources == "USER":
+                cols = settings.get("model_regions")
+            else:
+                cols = regional_load_sources.get("USER")
             if not all([col in hourly_load_profiles.columns for col in cols]):
                 raise KeyError(
                     f"One or more of the regions {cols} is not included in your "


### PR DESCRIPTION
Having the following in settings will raise an error:
```yaml
regional_load_source: USER
```
