### PR TITLE
Get retirement year

### DIFF
--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -1241,6 +1241,13 @@ def group_units(df, settings):
     grouped_units = grouped_units.replace([np.inf, -np.inf], np.nan)
     grouped_units = grouped_units.fillna(grouped_units.mean())
 
+    if settings.get("use_EIA_retirement_year"):
+        grouped_units["retirement_year"] = df_copy.groupby(by).apply(
+            lambda x: np.average(
+                x["retirement_year"], weights=x[settings["capacity_col"]]
+            )
+        )
+
     return grouped_units
 
 


### PR DESCRIPTION
Adds (weighted average) retirement year to grouped units if `use_EIA_retirement_year` is `True` in settings. `retirement_year` must also be in `generator_columns`.

Just a suggestion, feel free to not merge if this obfuscates other functionality.