### PR TITLE
Add storage energy capacity data

### DIFF
--- a/example_systems/CA_AZ/settings/resource_tags.yml
+++ b/example_systems/CA_AZ/settings/resource_tags.yml
@@ -69,6 +69,7 @@ model_tag_values:
     UtilityPV: 1
   STOR:
     Battery: 1
+    Batteries: 1
     Hydroelectric Pumped Storage: 1
   FLEX:
     ev_load_shifting: 1

--- a/example_systems/CA_AZ/settings/resources.yml
+++ b/example_systems/CA_AZ/settings/resources.yml
@@ -38,6 +38,7 @@ num_clusters:
   Hydroelectric Pumped Storage: 1
   Biomass: 1
   Other_peaker: 1
+  Batteries: 1
 
 
 # Group these technologies
@@ -177,7 +178,7 @@ atb_battery_wacc: UtilityPV
 # Format for ATB is <technology>_<tech_detail>, all are Mid cost case
 # Might want to change this to list format like the new generators below
 eia_atb_tech_map:
-  Battery: Battery_*
+  Batteries: Battery_*
   Biomass: Biopower_Dedicated
   Solar Thermal without Energy Storage: CSP_Class1
   Conventional Steam Coal: Coal_newAvgCF
@@ -338,7 +339,7 @@ cost_multiplier_technology_map:
 
 # PROPOSED GENERATOR VARIABLES
 
-eia_860m_fn: september_generator2021.xlsx
+eia_860m_fn: june_generator2022.xlsx
 
 # The status codes below exclude plants where regulatory approvals have not been
 # initiated or received. "Other" is also excluded.

--- a/example_systems/CA_AZ/settings/resources.yml
+++ b/example_systems/CA_AZ/settings/resources.yml
@@ -119,6 +119,10 @@ regional_hydro_factor:
 # name is contained in the dataframe technology name.
 energy_storage_duration:
   Hydroelectric Pumped Storage: 15.5
+  Batteries:
+    CA_S: 4
+    CA_N: 4
+    WECC_AZ: 2
 
 # Generator cost data from NREL ATB
 

--- a/example_systems/ISONE/settings/resource_tags.yml
+++ b/example_systems/ISONE/settings/resource_tags.yml
@@ -71,6 +71,7 @@ model_tag_values:
     UtilityPV: 1
     Offshore Wind Turbine: 1
   STOR:
+    Batteries: 1
     Battery: 1
     Hydroelectric Pumped Storage: 1
   FLEX:

--- a/example_systems/ISONE/settings/resources.yml
+++ b/example_systems/ISONE/settings/resources.yml
@@ -38,6 +38,7 @@ num_clusters:
   Hydroelectric Pumped Storage: 1
   Biomass: 1
   Other_peaker: 1
+  Batteries: 1
 
 
 # Group these technologies
@@ -110,6 +111,7 @@ regional_hydro_factor: ~
 # name is contained in the dataframe technology name.
 energy_storage_duration:
   Hydroelectric Pumped Storage: 15.5
+  Batteries: 2
 
 # Generator cost data from NREL ATB
 
@@ -170,7 +172,7 @@ atb_battery_wacc: UtilityPV
 # Format for ATB is <technology>_<tech_detail>, all are Mid cost case
 # Might want to change this to list format like the new generators below
 eia_atb_tech_map:
-  Battery: Battery_*
+  Batteries: Battery_*
   Biomass: Biopower_Dedicated
   Solar Thermal without Energy Storage: CSP_Class1
   Conventional Steam Coal: Coal_newAvgCF
@@ -330,7 +332,7 @@ cost_multiplier_technology_map:
 
 # PROPOSED GENERATOR VARIABLES
 
-eia_860m_fn: september_generator2021.xlsx
+eia_860m_fn: june_generator2022.xlsx
 
 # The status codes below exclude plants where regulatory approvals have not been
 # initiated or received. "Other" is also excluded.

--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -1109,3 +1109,34 @@ def hydro_energy_to_power(
             ] = avg_inflow.where(avg_inflow > 1, 1)
     df["Hydro_Energy_to_Power_Ratio"] = df["Hydro_Energy_to_Power_Ratio"].fillna(0)
     return df
+
+
+def rename_gen_cols(
+    df: pd.DataFrame, rename_cols: Dict[str, str] = None
+) -> pd.DataFrame:
+    """Rename columns in the generators data file.
+
+    By default the only rename so far is "existing_mwh" to "Existing_Cap_MWh".
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Final dataframe of generating resources.
+    rename_cols : Dict[str, str], optional
+        Additional rename pairs, by default None
+
+    Returns
+    -------
+    pd.DataFrame
+        Identical to input dataframe except for renamed columns.
+    """
+
+    rename = {
+        "capacity_mwh": "Existing_Cap_MWh",
+    }
+    if rename_cols:
+        rename.update(rename_cols)
+
+    df = df.rename(columns=rename, errors="ignore")
+
+    return df

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -76,6 +76,8 @@ planned_col_map = {
     "Planned Operation Month": "planned_operating_month",
     "Planned Operation Year": "planned_operating_year",
     "Status": "operational_status",
+    "Nameplate Energy Capacity (MWh)": "capacity_mwh",
+    "DC Net Capacity (MW)": "dc_net_capacity_mw",
     "County": "county",
     "Latitude": "latitude",
     "Longitude": "longitude",
@@ -1232,6 +1234,7 @@ def group_units(df, settings):
     grouped_units = df_copy.groupby(by).agg(
         {
             settings["capacity_col"]: "sum",
+            "capacity_mwh": "sum",
             "minimum_load_mw": "sum",
             "heat_rate_mmbtu_mwh": "mean",
             "Fixed_OM_Cost_per_MWyr": "mean",
@@ -1296,6 +1299,7 @@ def calc_unit_cluster_values(
     df_values = df.groupby("cluster").agg(
         {
             capacity_col: "mean",
+            "capacity_mwh": wm,
             "minimum_load_mw": "mean",
             "heat_rate_mmbtu_mwh": wm,
             "Fixed_OM_Cost_per_MWyr": wm,
@@ -1678,6 +1682,7 @@ def import_new_generators(
         "technology_description",
         "generator_id",
         settings["capacity_col"],
+        "capacity_mwh",
         "minimum_load_mw",
         "operational_status_code",
         "heat_rate_mmbtu_mwh",
@@ -1686,7 +1691,7 @@ def import_new_generators(
         "state",
     ]
 
-    return new_operating.loc[:, keep_cols]
+    return new_operating.reindex(columns=keep_cols)
 
 
 def import_proposed_generators(
@@ -2378,7 +2383,8 @@ def energy_storage_mwh(
     pd.DataFrame
         Modified dataframe with energy storage values
     """
-    all_regions = df["region"].unique()
+    region_col = [c for c in df.columns if "region" in c.lower()][0]
+    all_regions = df[region_col].unique()
     for tech, val in energy_storage_duration.items():
         if isinstance(val, dict):
             tech_regions = val.keys()
@@ -2403,14 +2409,16 @@ def energy_storage_mwh(
                     )
                 df.loc[
                     (snake_case_col(df[tech_col]).str.contains(snake_case_str(tech)))
-                    & (df["region"] == region),
+                    & (df["region"] == region)
+                    & ~(df[energy_col] > 0),
                     energy_col,
                 ] = (
                     df[cap_col] * v
                 )
         else:
             df.loc[
-                snake_case_col(df[tech_col]).str.contains(snake_case_str(tech)),
+                snake_case_col(df[tech_col]).str.contains(snake_case_str(tech))
+                & ~(df[energy_col] > 0),
                 energy_col,
             ] = (
                 df[cap_col] * val
@@ -2517,6 +2525,30 @@ def load_demand_response_efs_profile(
         dr_profile = dr_profile.drop(columns=base_regs)
 
     return dr_profile
+
+
+def add_860m_storage_mwh(
+    gen_df: pd.DataFrame, operating_860m: pd.DataFrame, storage_techs: List[str] = None
+) -> pd.DataFrame:
+    idx_cols = ["plant_id_eia", "generator_id"]
+    gen_df = gen_df.set_index(idx_cols)
+
+    if not storage_techs:
+        storage_techs = [
+            "Batteries",
+            "Natural Gas with Compressed Air Storage",
+            "Flywheels",
+        ]
+
+    storage_860m = operating_860m.loc[
+        operating_860m.technology_description.isin(storage_techs), :
+    ].set_index(idx_cols)
+    gen_df.loc[storage_860m.index, "capacity_mwh"] = storage_860m["capacity_mwh"]
+    # gen_df = pd.merge(
+    #     gen_df, storage_860m[idx_cols + ["capacity_mwh"]], how="left", on=idx_cols
+    # )
+
+    return gen_df.reset_index()
 
 
 class GeneratorClusters:
@@ -2907,6 +2939,19 @@ class GeneratorClusters:
         # Create a pudl unit id based on plant and generator id where one doesn't exist.
         # This is used later to match the cluster numbers to plants
         self.units_model.reset_index(inplace=True)
+        self.units_model = add_860m_storage_mwh(
+            self.units_model,
+            self.new_860m_gens.reset_index(),
+            storage_techs=["Batteries"],
+        )
+        if self.settings.get("energy_storage_duration"):
+            self.units_model = energy_storage_mwh(
+                self.units_model,
+                self.settings["energy_storage_duration"],
+                "technology_description",
+                self.settings["capacity_col"],
+                "capacity_mwh",
+            )
         self.units_model.loc[self.units_model.unit_id_pudl.isnull(), "unit_id_pudl"] = (
             self.units_model.loc[
                 self.units_model.unit_id_pudl.isnull(), "plant_id_eia"
@@ -3143,14 +3188,6 @@ class GeneratorClusters:
         if self.settings.get("derate_capacity"):
             self.results["unmodified_existing_cap_mw"] = (
                 self.results["unmodified_cap_size"] * self.results["num_units"]
-            )
-        if self.settings.get("energy_storage_duration"):
-            self.results = energy_storage_mwh(
-                self.results,
-                self.settings["energy_storage_duration"],
-                "technology",
-                "Existing_Cap_MW",
-                "Existing_Cap_MWh",
             )
 
         if self.settings.get("region_wind_pv_cap_fn"):

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -51,6 +51,7 @@ from powergenome.util import (
     snake_case_str,
     load_ipm_shapefile,
 )
+from powergenome.GenX import rename_gen_cols
 from scipy.stats import iqr
 from sklearn import cluster, preprocessing
 from xlrd import XLRDError
@@ -3274,6 +3275,8 @@ class GeneratorClusters:
                 utc_offset=self.settings.get("utc_offset", 0),
             )
             self.results["profile"][i] = clusters["profile"][0]
+
+        self.results = rename_gen_cols(self.results)
 
         return self.results
 

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -1301,7 +1301,7 @@ def calc_unit_cluster_values(
     df_values = df.groupby("cluster", as_index=False).agg(
         {
             capacity_col: "mean",
-            "capacity_mwh": wm,
+            "capacity_mwh": "sum",
             "minimum_load_mw": "mean",
             "heat_rate_mmbtu_mwh": wm,
             "Fixed_OM_Cost_per_MWyr": wm,

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -1293,7 +1293,7 @@ def calc_unit_cluster_values(
         cap_diff = start_cap - end_cap
         logger.warning(f"dropped {cap_diff}MW because of null heat rate values")
 
-    df_values = df.groupby("cluster", as_index=False).agg(
+    df_values = df.groupby("cluster").agg(
         {
             capacity_col: "mean",
             "minimum_load_mw": "mean",
@@ -1302,6 +1302,7 @@ def calc_unit_cluster_values(
             "Var_OM_Cost_per_MWh": wm,
         }
     )
+    df_values["cluster"] = df_values.index
     if df_values["heat_rate_mmbtu_mwh"].isnull().values.any():
         print(df)
         print(df_values)

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -2946,11 +2946,14 @@ class GeneratorClusters:
         # Create a pudl unit id based on plant and generator id where one doesn't exist.
         # This is used later to match the cluster numbers to plants
         self.units_model.reset_index(inplace=True)
-        self.units_model = add_860m_storage_mwh(
-            self.units_model,
-            self.new_860m_gens.reset_index(),
-            storage_techs=["Batteries"],
-        )
+        if self.supplement_with_860m:
+            self.units_model = add_860m_storage_mwh(
+                self.units_model,
+                self.new_860m_gens.reset_index(),
+                storage_techs=["Batteries"],
+            )
+        else:
+            self.units_model["capacity_mwh"] = 0
         if self.settings.get("energy_storage_duration"):
             self.units_model = energy_storage_mwh(
                 self.units_model,

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -1297,7 +1297,7 @@ def calc_unit_cluster_values(
         cap_diff = start_cap - end_cap
         logger.warning(f"dropped {cap_diff}MW because of null heat rate values")
 
-    df_values = df.groupby("cluster").agg(
+    df_values = df.groupby("cluster", as_index=False).agg(
         {
             capacity_col: "mean",
             "capacity_mwh": wm,
@@ -1307,7 +1307,7 @@ def calc_unit_cluster_values(
             "Var_OM_Cost_per_MWh": wm,
         }
     )
-    df_values["cluster"] = df_values.index
+    df_values.index = df_values["cluster"].values
     if df_values["heat_rate_mmbtu_mwh"].isnull().values.any():
         print(df)
         print(df_values)

--- a/powergenome/load_construction.py
+++ b/powergenome/load_construction.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from powergenome.util import (
     deep_freeze_args,
+    find_region_col,
     snake_case_col,
 )
 from powergenome.params import DATA_PATHS, SETTINGS
@@ -91,7 +92,8 @@ def load_region_pop_frac(
     elif (path_in / fn).suffix == ".parquet":
         pop = pd.read_parquet(path_in / fn)
     pop["state"] = pop["state"].map(us_state_abbrev)
-    region_col = [c for c in pop.columns if "region" in c][0]
+    context = "Loading region population fraction file for EFS load construction."
+    region_col = find_region_col(pop.columns, context)
     pop = pop.rename(columns={region_col: "region"})
     pop_cols = ["region", "state", "state_prop"]
     return pop[pop_cols]

--- a/tests/generation_test.py
+++ b/tests/generation_test.py
@@ -63,6 +63,7 @@ from powergenome.transmission import (
 )
 from powergenome.util import (
     build_scenario_settings,
+    find_region_col,
     init_pudl_connection,
     check_settings,
     load_settings,
@@ -969,3 +970,22 @@ def test_load_growth(CA_AZ_settings):
 def test_db_col_values():
     values = db_col_values(pg_engine, "technology_costs_nrelatb", ["technology"])
     assert "NaturalGas" in values
+
+
+def test_find_region_col():
+
+    df = pd.DataFrame(columns=["A", "Region", "C"])
+    region_col = find_region_col(df.columns)
+    assert region_col == "Region"
+
+    df = pd.DataFrame(columns=["A", "model_region", "C"])
+    region_col = find_region_col(df.columns)
+    assert region_col == "model_region"
+
+    with pytest.raises(ValueError):
+        df = pd.DataFrame(columns=["A", "model_region", "region"])
+        region_col = find_region_col(df.columns)
+
+    with pytest.raises(ValueError):
+        df = pd.DataFrame(columns=["A", "B", "C"])
+        region_col = find_region_col(df.columns)


### PR DESCRIPTION
Use EIA 860m to fill in energy capacity (MWh) data for storage techs. Then use the settings parameter `energy_storage_duration` to fill missing data.