### PR TITLE
Modify fuel prices by model region

### DIFF
--- a/tests/fuel_test.py
+++ b/tests/fuel_test.py
@@ -37,7 +37,7 @@ pudl_engine, pudl_out, pg_engine = init_pudl_connection(
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def fuel_settings():
     settings = {
         "modified_atb_new_gen": {

--- a/tests/fuel_test.py
+++ b/tests/fuel_test.py
@@ -298,3 +298,17 @@ def test_regional_fuel_price_mod(fuel_settings):
             fuel_settings["aeo_fuel_region_map"],
             fuel_settings.get("regional_fuel_adjustments"),
         )
+
+
+def test_regional_mod_fuel_labels(fuel_settings):
+    fuel_settings["regional_fuel_adjustments"] = {
+        "S_VACA": ["mul", 2],
+        "PJM_Dom": {"naturalgas": ["add", 1]},
+    }
+    fuel_settings["target_usd_year"] = 2020
+    gc = GeneratorClusters(
+        pudl_engine, pudl_out, pg_engine, fuel_settings, current_gens=False
+    )
+    gens = gc.create_new_generators()
+    assert "S_VACA_reference_naturalgas" in gens.Fuel.values
+    assert "PJM_Dom_reference_naturalgas" in gens.Fuel.values


### PR DESCRIPTION
As described in #210. 

@bradenpecora this is a start. So far it just modifies the fuel prices dataframe and creates new fuel names based on model regions. I'll still need to modify fuel labels for generator clusters but I think the code should work as-is after that.