### PR TITLE
Load and use interregional tx costs from file

### DIFF
--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -39,7 +39,11 @@ from powergenome.transmission import (
     transmission_line_distance,
 )
 from powergenome.nrelatb import atb_fixed_var_om_existing
-from powergenome.external_data import make_generator_variability
+from powergenome.external_data import (
+    insert_user_tx_costs,
+    load_user_tx_costs,
+    make_generator_variability,
+)
 from powergenome.util import (
     build_scenario_settings,
     check_settings,
@@ -373,19 +377,29 @@ def main():
 
             if args.transmission:
                 model_regions_gdf = gc.model_regions_gdf
-                transmission = (
-                    agg_transmission_constraints(
+                if _settings.get("user_transmission_costs"):
+                    user_tx_costs = load_user_tx_costs(
+                        _settings["extra_inputs"] / _settings["user_transmission_costs"]
+                    )
+                    transmission = agg_transmission_constraints(
                         pg_engine=pg_engine, settings=_settings
+                    ).pipe(insert_user_tx_costs, user_costs=user_tx_costs)
+                else:
+                    transmission = (
+                        agg_transmission_constraints(
+                            pg_engine=pg_engine, settings=_settings
+                        )
+                        .pipe(
+                            transmission_line_distance,
+                            ipm_shapefile=model_regions_gdf,
+                            settings=_settings,
+                            units="mile",
+                        )
+                        .pipe(network_line_loss, settings=_settings)
+                        .pipe(network_reinforcement_cost, settings=_settings)
                     )
-                    .pipe(
-                        transmission_line_distance,
-                        ipm_shapefile=model_regions_gdf,
-                        settings=_settings,
-                        units="mile",
-                    )
-                    .pipe(network_line_loss, settings=_settings)
-                    .pipe(network_max_reinforcement, settings=_settings)
-                    .pipe(network_reinforcement_cost, settings=_settings)
+                transmission = (
+                    transmission.pipe(network_max_reinforcement, settings=_settings)
                     .pipe(set_int_cols)
                     .pipe(round_col_values)
                     .pipe(add_cap_res_network, settings=_settings)

--- a/tests/transmission_test.py
+++ b/tests/transmission_test.py
@@ -1,0 +1,132 @@
+"Test functions for interregional transmission lines"
+
+from collections import namedtuple
+import os
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import pytest
+
+from powergenome.util import (
+    build_scenario_settings,
+    load_settings,
+    init_pudl_connection,
+)
+from powergenome.params import DATA_PATHS
+from powergenome.external_data import load_user_tx_costs, insert_user_tx_costs
+from powergenome.transmission import agg_transmission_constraints
+
+if os.name == "nt":
+    # if user is using a windows system
+    sql_prefix = "sqlite:///"
+else:
+    sql_prefix = "sqlite:////"
+pudl_engine, pudl_out, pg_engine = init_pudl_connection(
+    pudl_db=sql_prefix + str(DATA_PATHS["test_data"] / "pudl_test_data.db"),
+    pg_db=sql_prefix + str(DATA_PATHS["test_data"] / "pg_misc_tables.sqlite3"),
+)
+
+
+@pytest.fixture(scope="module")
+def CA_AZ_settings():
+    settings = load_settings(
+        DATA_PATHS["powergenome"].parent / "example_systems" / "CA_AZ" / "settings"
+    )
+    settings["input_folder"] = Path(
+        DATA_PATHS["powergenome"].parent
+        / "example_systems"
+        / "CA_AZ"
+        / settings["input_folder"]
+    )
+    settings["RESOURCE_GROUPS"] = DATA_PATHS["test_data"] / "resource_groups_base"
+    scenario_definitions = pd.read_csv(
+        settings["input_folder"] / settings["scenario_definitions_fn"]
+    )
+    scenario_settings = build_scenario_settings(settings, scenario_definitions)
+
+    return scenario_settings[2030]["p1"]
+
+
+def test_load_user_tx(tmp_path):
+    cols = [
+        "start_region",
+        "dest_region",
+        "total_interconnect_annuity_mw",
+        "total_interconnect_cost_mw",
+        "total_line_loss_frac",
+        "dollar_year",
+    ]
+    tx_line = namedtuple("tx_line", cols)
+    lines = [
+        tx_line("CA_S", "WECC_AZ", 1000, 100000, 0.07, 2018),
+        tx_line("CA_N", "CA_N", 2000, 200000, 0.06, 2018),
+    ]
+    user_tx = pd.DataFrame(lines)
+    user_tx.to_csv(tmp_path / "tx_lines.csv", index=False)
+
+    model_regions = ["CA_N", "CA_S", "WECC_AZ"]
+    target_usd_year = 2020
+
+    user_tx_costs = load_user_tx_costs(
+        tmp_path / "tx_lines.csv", model_regions, target_usd_year
+    )
+
+    assert all(
+        user_tx_costs["total_interconnect_annuity_mw"]
+        > user_tx["total_interconnect_annuity_mw"]
+    )
+
+    user_tx_costs = load_user_tx_costs(
+        tmp_path / "tx_lines.csv", model_regions, target_usd_year=None
+    )
+
+    assert np.allclose(
+        user_tx_costs["total_interconnect_annuity_mw"],
+        user_tx["total_interconnect_annuity_mw"],
+    )
+
+
+def test_insert_user_tx_costs(tmp_path, CA_AZ_settings):
+    cols = [
+        "start_region",
+        "dest_region",
+        "total_interconnect_annuity_mw",
+        "total_interconnect_cost_mw",
+        "total_line_loss_frac",
+        "dollar_year",
+    ]
+    tx_line = namedtuple("tx_line", cols)
+    lines = [
+        tx_line("CA_S", "WECC_AZ", 1000, 100000, 0.07, 2018),
+        tx_line("CA_N", "CA_N", 2000, 200000, 0.06, 2018),
+    ]
+    user_tx = pd.DataFrame(lines)
+    user_tx.to_csv(tmp_path / "tx_lines.csv", index=False)
+    model_regions = ["CA_N", "CA_S", "WECC_AZ"]
+    target_usd_year = 2020
+
+    user_tx = load_user_tx_costs(
+        tmp_path / "tx_lines.csv", model_regions, target_usd_year
+    )
+
+    tx_constraints = agg_transmission_constraints(
+        pg_engine,
+        CA_AZ_settings,
+    )
+
+    combined_tx = insert_user_tx_costs(tx_constraints, user_tx)
+
+    assert len(combined_tx) == 2
+
+    req_cols = [
+        "Network_Lines",
+        "z1",
+        "z2",
+        "z3",
+        "Line_Reinforcement_Cost_per_MWyr",
+        "Line_Reinforcement_Cost_per_MW",
+        "Line_Loss_Percentage",
+    ]
+    for col in req_cols:
+        assert col in combined_tx.columns
+        assert combined_tx[col].notnull().all()


### PR DESCRIPTION
Let a user specify interregional transmission costs and losses in a CSV file. This can include lines between regions with no existing transmission connection.