### PR TITLE
Fix incorrect gen var time index when 8760 hours

### DIFF
--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -500,6 +500,7 @@ def reduce_time_domain(
             ],
             axis=1,
         )
+        resource_profiles.index = time_index
 
         return resource_profiles, load_output, None, None
 


### PR DESCRIPTION
Time_Index should start at 1 but it was never changed when time domain isn't reduced.