### PR TITLE
Tx expansion MW

### DIFF
--- a/example_systems/CA_AZ/settings/transmission.yml
+++ b/example_systems/CA_AZ/settings/transmission.yml
@@ -26,5 +26,6 @@ transmission_investment_cost:
 
 # Percent expansion in planning period above and beyond existing transmission
 tx_expansion_per_period: 1.0
+tx_expansion_mw_per_period: 400
 
 tx_line_loss_100_miles: 0.01

--- a/example_systems/ISONE/settings/transmission.yml
+++ b/example_systems/ISONE/settings/transmission.yml
@@ -26,5 +26,6 @@ transmission_investment_cost:
 
 # Percent expansion in planning period above and beyond existing transmission
 tx_expansion_per_period: 1.0
+tx_expansion_mw_per_period: 400
 
 tx_line_loss_100_miles: 0.01

--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -634,6 +634,7 @@ def network_max_reinforcement(
     """
 
     max_expansion = settings.get("tx_expansion_per_period")
+    expansion_mw = settings.get("tx_expansion_mw_per_period", 0)
 
     if not max_expansion and max_expansion != 0:
         raise KeyError(
@@ -667,9 +668,9 @@ def network_max_reinforcement(
     #         )
 
     # else:
-    transmission.loc[:, "Line_Max_Reinforcement_MW"] = (
-        transmission.loc[:, "Line_Max_Flow_MW"] * max_expansion
-    )
+    transmission.loc[:, "Line_Max_Reinforcement_MW"] = [
+        max(tx * max_expansion, expansion_mw) for tx in transmission["Line_Max_Flow_MW"]
+    ]
     transmission["Line_Max_Reinforcement_MW"] = transmission[
         "Line_Max_Reinforcement_MW"
     ].round(0)

--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -633,7 +633,7 @@ def network_max_reinforcement(
         `Line_Max_Reinforcement_MW`.
     """
 
-    max_expansion = settings.get("tx_expansion_per_period")
+    max_expansion = settings.get("tx_expansion_per_period", 0)
     expansion_mw = settings.get("tx_expansion_mw_per_period", 0)
 
     if not max_expansion and max_expansion != 0:


### PR DESCRIPTION
Set transmission line max expansion as either a fraction of existing or as a MW value. If both are included in settings then use the larger value for each line.

This lets users set something like 400 MW, which would be roughly equal to a 230kV line.