### PR TITLE
Fix flexible demand load profile UTC shift bug

### DIFF
--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -2687,6 +2687,7 @@ def load_demand_response_efs_profile(
         year=model_year,
         elec_scenario=electrification_scenario,
         regions=keep_regions,
+        utc_offset=utc_offset or 0,
         path_in=path_in,
     )
 
@@ -2707,9 +2708,6 @@ def load_demand_response_efs_profile(
         ).sum(axis=1)
         dr_profile = dr_profile.drop(columns=base_regs, errors="ignore")
 
-    if utc_offset:
-        for col in dr_profile.columns:
-            dr_profile[col] = np.roll(dr_profile[col].values, utc_offset)
     return dr_profile
 
 

--- a/powergenome/load_construction.py
+++ b/powergenome/load_construction.py
@@ -330,7 +330,7 @@ def electrification_profiles(
     for name, (sector, subsector) in running_sectors.items():
         df = create_subsector_ts(
             sector, subsector, year, scenario_stock, utc_offset, path_in
-        ).pipe(state_demand_to_region, pop, name)
+        ).pipe(state_demand_to_region, pop)
 
         df["resource"] = name
         subsector_ts_dfs.append(df)

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -686,6 +686,7 @@ def make_final_load_curves(
             settings["model_year"],
             settings.get("electrification_scenario"),
             keep_regions,
+            settings.get("utc_offset", 0),
             settings.get("EFS_DATA"),
         )
         flex_profiles = map_agg_region_names(


### PR DESCRIPTION
The hourly demand for flexible subsectors was not being shifted from UTC when building up total demand profiles. The same issue had been identified for the resource profiles of flexible resources, and was fixed within `generators.py`. This PR moves the fix into `load_construction.py`, shifting demand profiles from UTC immediately after they are loaded.