### PR TITLE
Allow RG profiles to live in a single location

### DIFF
--- a/powergenome/params.py
+++ b/powergenome/params.py
@@ -44,6 +44,7 @@ SETTINGS["EIA_API_KEY"] = os.environ.get("EIA_API_KEY")
 SETTINGS["EFS_DATA"] = os.environ.get("EFS_DATA")
 SETTINGS["RESOURCE_GROUPS"] = os.environ.get("RESOURCE_GROUPS")
 SETTINGS["DISTRIBUTED_GEN_DATA"] = os.environ.get("DISTRIBUTED_GEN_DATA")
+SETTINGS["RESOURCE_GROUP_PROFILES"] = os.environ.get("RESOURCE_GROUP_PROFILES")
 
 
 def build_resource_clusters(group_path: Union[str, Path] = None):

--- a/powergenome/resource_clusters.py
+++ b/powergenome/resource_clusters.py
@@ -439,11 +439,26 @@ class ResourceGroup:
         profiles: pd.DataFrame = None,
         path: str = ".",
     ) -> None:
+        from powergenome.params import SETTINGS
+
         self.group = {"existing": False, "tree": None, **group.copy()}
-        for key in ["metadata", "profiles"]:
-            if self.group.get(key):
-                # Convert relative paths (relative to group file) to absolute paths
-                self.group[key] = Path(path) / self.group[key]
+
+        # Convert relative paths (relative to group file) to absolute paths
+        # Profiles may be stored in a single location and reused across resource groups
+        if self.group.get("metadata"):
+            self.group["metadata"] = Path(path) / self.group["metadata"]
+        if self.group.get("profiles"):
+            if (
+                SETTINGS.get("RESOURCE_GROUP_PROFILES")
+                and (
+                    Path(SETTINGS["RESOURCE_GROUP_PROFILES"]) / self.group["profiles"]
+                ).exists()
+            ):
+                self.group["profiles"] = (
+                    Path(SETTINGS["RESOURCE_GROUP_PROFILES"]) / self.group["profiles"]
+                )
+            else:
+                self.group["profiles"] = Path(path) / self.group["profiles"]
         required = ["technology"]
         if metadata is None:
             required.append("metadata")


### PR DESCRIPTION
Add new .env param with profile locations.
Set a single folder with the location of wind/solar profiles so it doesn't need to be reused in ever new set of resource group files.