### PR TITLE
Sort settings keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-    -   id: check-yaml
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: check-yaml
     # -   id: end-of-file-fixer
-    -   id: trailing-whitespace
-    -   id: check-added-large-files
-        args: ['--maxkb=80000']
--   repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-    -   id: black
+  - id: trailing-whitespace
+  - id: check-added-large-files
+      args: ['--maxkb=80000']
+- repo: https://github.com/psf/black
+  rev: 23.3.0
+  hooks:
+  - id: black
 - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
+  rev: 5.12.0
+  hooks:
+  - id: isort

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -55,6 +55,7 @@ from powergenome.util import (
     reverse_dict_of_lists,
     snake_case_col,
     snake_case_str,
+    sort_nested_dict,
 )
 
 logger = logging.getLogger(__name__)
@@ -1427,7 +1428,10 @@ def add_genx_model_tags(df, settings):
             settings["generator_columns"].append(tag_col)
 
         try:
-            for tech, tag_value in settings["model_tag_values"][tag_col].items():
+            for tech, tag_value in sorted(
+                settings["model_tag_values"][tag_col].items(),
+                key=lambda item: len(item[0]),
+            ):
                 tech = re.sub(ignored, "", tech)
                 mask = technology.str.contains(rf"^{tech}", case=False)
                 df.loc[mask, tag_col] = tag_value
@@ -1435,7 +1439,9 @@ def add_genx_model_tags(df, settings):
             logger.warning(f"No model tag values found for {tag_col} ({e})")
 
     # Change tags with specific regional values for a technology
-    flat_regional_tags = flatten(settings.get("regional_tag_values", {}) or {})
+    flat_regional_tags = flatten(
+        sort_nested_dict(settings.get("regional_tag_values", {}) or {})
+    )
 
     for tag_tuple, tag_value in flat_regional_tags.items():
         region, tag_col, tech = tag_tuple

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 
 import powergenome
-from powergenome.util import apply_all_tag_to_regions
+from powergenome.util import apply_all_tag_to_regions, sort_nested_dict
 
 
 logger = logging.getLogger(powergenome.__name__)
@@ -19,6 +19,25 @@ formatter = logging.Formatter(
 )
 handler.setFormatter(formatter)
 logger.addHandler(handler)
+
+
+def test_sort_nested_dict():
+    test_dict1 = {"one": 1, "threeee": 3, "twoo": 2}
+    sorted_dict1 = sort_nested_dict(test_dict1)
+    # Here, the keys should be ordered as 'one', 'twoo' and 'threeee'
+    assert list(sorted_dict1.keys()) == ["one", "twoo", "threeee"]
+
+    test_dict2 = {"threeee": {"fourrrrr": 4, "twoo": 2}, "one": 1, "fiveeeee": 5}
+    sorted_dict2 = sort_nested_dict(test_dict2)
+    # Here, the keys at the top level should be ordered as 'one', 'threeee' and 'fiveeeee'
+    assert list(sorted_dict2.keys()) == ["one", "threeee", "fiveeeee"]
+    # And within the dictionary mapped to by 'threeee', the keys should be 'twoo' and 'fourrrrr'
+    assert list(sorted_dict2["threeee"].keys()) == ["twoo", "fourrrrr"]
+
+    test_dict3 = {"a": {"b": 4, "a": 2}, "c": 1, "b": 5}
+    sorted_dict3 = sort_nested_dict(test_dict3)
+    assert list(sorted_dict3.keys()) == ["a", "c", "b"]
+    assert list(sorted_dict3["a"].keys()) == ["b", "a"]
 
 
 def test_apply_all_tag_to_regions(caplog):


### PR DESCRIPTION
Sort keys in settings dictionaries by length. This is important when specifying technologies by name as keys. Shorter keys (`nuclear`) should not be applied to all techs where they are a subset of the longer key (`nuclear_nuclear`).