### PR TITLE
Fix misc gen bug

### DIFF
--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -392,7 +392,7 @@ def add_misc_gen_values(
             )
     generic_resources = []
     for gen_resource in gen_clusters[resource_col].unique():
-        for r in settings["model_regions"]:
+        for r in sorted(settings["model_regions"])[::-1]:
             if r in gen_resource:
                 gen_resource = gen_resource.replace(r + "_", "")
                 generic_resources.append(gen_resource)

--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -16,7 +16,12 @@ from powergenome.external_data import (
 from powergenome.load_profiles import make_distributed_gen_profiles
 from powergenome.nrelatb import investment_cost_calculator
 from powergenome.time_reduction import kmeans_time_clustering
-from powergenome.util import find_region_col, load_settings, snake_case_col
+from powergenome.util import (
+    find_region_col,
+    load_settings,
+    snake_case_col,
+    snake_case_str,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -395,7 +395,7 @@ def add_misc_gen_values(
         for r in sorted(settings["model_regions"])[::-1]:
             if r in gen_resource:
                 gen_resource = gen_resource.replace(r + "_", "")
-                generic_resources.append(gen_resource)
+                generic_resources.append(snake_case_str(gen_resource))
                 continue
     generic_resources = set(generic_resources)
     missing_resources = []
@@ -423,7 +423,11 @@ def add_misc_gen_values(
         row_cols = row[value_cols].dropna().index
         gen_clusters.loc[
             (gen_clusters["region"] == row[region_col])
-            & (gen_clusters[resource_col].str.contains(row[resource_col], case=False)),
+            & (
+                snake_case_col(gen_clusters[resource_col]).str.contains(
+                    row[resource_col], case=False
+                )
+            ),
             row_cols,
         ] = row[row_cols].values
     return gen_clusters


### PR DESCRIPTION
With ATB 2023, some of the technology details include "-" in the names. The functions that convert strings to snake case remove dashes, which lead to incorrect string matching. Applying snake case to technology names from both files ensures that they should be compatible.

Separately, if there are two model regions and one is a subset of the other with an under score (e.g. `TRE` and `TRE_WEST`), the user will see a warning about some resources not being included in the misc gen inputs file. Reverse sorting the model regions should fix this.