### PR TITLE
make case_id mapping optional

### DIFF
--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -253,9 +253,14 @@ def main(**kwargs):
     model_regions_gdf = None
     for year in scenario_settings:
         for case_id, _settings in scenario_settings[year].items():
-            case_folder = (
-                out_folder / f"{year}" / f"{case_id}_{year}_{_settings['case_name']}"
-            )
+            if settings.get("case_name"):
+                case_folder = (
+                    out_folder
+                    / f"{year}"
+                    / f"{case_id}_{year}_{_settings['case_name']}"
+                )
+            else:
+                case_folder = out_folder / f"{year}" / f"{case_id}_{year}"
             _settings["extra_outputs"] = case_folder / "extra_outputs"
             _settings["extra_outputs"].mkdir(parents=True, exist_ok=True)
             logger.info(f"Starting year {year} scenario {case_id}\n")

--- a/powergenome/util.py
+++ b/powergenome/util.py
@@ -898,8 +898,10 @@ def build_scenario_settings(
             "either the key 'model_periods' (a list of 2-element lists) or the keys "
             "'model_year' and 'model_first_planning_year' (each a list of years)."
         )
-
-    case_id_name_map = build_case_id_name_map(settings)
+    if settings.get("case_id_description_fn"):
+        case_id_name_map = build_case_id_name_map(settings)
+    else:
+        case_id_name_map = None
 
     scenario_settings = {}
     for year in model_planning_period_dict.keys():
@@ -973,7 +975,8 @@ def build_scenario_settings(
 
             _settings["model_first_planning_year"] = model_planning_period_dict[year][0]
             _settings["model_year"] = model_planning_period_dict[year][1]
-            _settings["case_name"] = case_id_name_map[case_id]
+            if settings.get("case_id_description_fn"):
+                _settings["case_name"] = case_id_name_map[case_id]
             scenario_settings[year][case_id] = _settings
 
     return scenario_settings


### PR DESCRIPTION
The case_id to long name mapping has become a pain, especially because it requires updating 2 files to create a new case. Make optional.