### PR TITLE
Fix atb mapping hr bug

### DIFF
--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -417,10 +417,32 @@ def atb_fixed_var_om_existing(
     existing_year = settings["atb_existing_year"]
 
     techs = {}
+    missing_techs = []
     for eia, atb in settings["eia_atb_tech_map"].items():
         if not isinstance(atb, list):
             atb = [atb]
-        techs[eia] = atb[0].split("_")
+        missing = True
+        for tech_detail in atb:
+            tech, detail = tech_detail.split("_")
+            if not atb_hr_df.query(
+                "technology == @tech and tech_detail == @detail"
+            ).empty:
+                techs[eia] = [tech, detail]
+                missing = False
+                break
+        if missing is True and eia in results["technology"].unique():
+            missing_techs.append(eia)
+
+        # techs[eia] = atb[0].split("_")
+    if missing_techs:
+        s = (
+            f"The EIA technologies {missing_techs} do not have an ATB counterpart with a "
+            "valid heat rate. Not all ATB technologies *should* have a valid heat rate "
+            "(e.g. wind, solar, and hydro). Check the 'eia_atb_tech_map' parameter in your "
+            "settings file(s) if you think one of these technologies should be mapped to "
+            "an ATB technology with a valid heat rate."
+        )
+        logger.warning(s)
 
     target_usd_year = settings["target_usd_year"]
     simple_o_m = {

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -641,7 +641,7 @@ def calc_om(
     except (ValueError, TypeError, KeyError):
         # Not all technologies have a heat rate. If they don't, just set both values
         # to 10.34 (33% efficiency)
-        df["heat_rate_mmbtu_mwh"] = 10.34
+        df.loc[df["heat_rate_mmbtu_mwh"].isna(), "heat_rate_mmbtu_mwh"] = 10.34
         new_build_hr = 10.34
 
     try:


### PR DESCRIPTION
Related to calculating/assigning fixed and variable O&M for existing generators.

1. When a list of potential ATB technologies are provided for mapping, look through the list and find one with values in the atb_hr_df data frame. Alert the user if one or more of the EIA technologies does not have a listed ATB counterpart with a valid heat rate. Even if there is a valid mapping not all ATB techs (solar, wind, hydro, geothermal) will have a heat rate.
2. When assigning O&M values for existing generators, only assign a heat rate of 10.34 if the existing generator has a NaN heat rate. Otherwise keep whatever value was passed in.