### PR TITLE
Warn if VRE/HYDRO profiles are not variable

### DIFF
--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -26,6 +26,7 @@ from powergenome.GenX import (
     add_misc_gen_values,
     calculate_partial_CES_values,
     check_resource_tags,
+    check_vre_profiles,
     create_policy_req,
     create_regional_cap_res,
     fix_min_power_values,
@@ -344,6 +345,7 @@ def main(**kwargs):
                 gens = fix_min_power_values(gen_clusters, gen_variability).pipe(
                     add_co2_costs_to_o_m
                 )
+                check_vre_profiles(gens, gen_variability)
                 for col in _settings["generator_columns"]:
                     if col not in gens.columns:
                         gens[col] = 0

--- a/tests/genx_test.py
+++ b/tests/genx_test.py
@@ -1,7 +1,9 @@
+import logging
+
 import pandas as pd
 import pytest
 
-from powergenome.GenX import set_must_run_generation
+from powergenome.GenX import check_vre_profiles, set_must_run_generation
 
 
 # Tests setting the generation of a single must run resource to 1 in all hours.
@@ -86,3 +88,65 @@ def test_set_must_run_generation_tech_not_found(caplog):
             set_must_run_generation(gen_variability, must_run_techs), expected_output
         )
         assert "Trying to set gen_4 as a must run resource" in caplog.text
+
+
+class TestCheckVreProfiles:
+
+    # Given a dataframe of generators with a "Resource" column and a dataframe of hourly generation for each resource, when all VRE resources have variable generation profiles, then no warning is issued.
+    def test_all_vre_variable_profiles(self, caplog):
+        gen_df = pd.DataFrame({"Resource": ["VRE1", "VRE2", "VRE3"], "VRE": [1, 1, 1]})
+        gen_var_df = pd.DataFrame(
+            {"VRE1": [0, 1, 0], "VRE2": [1, 0, 1], "VRE3": [0, 1, 0]}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            check_vre_profiles(gen_df, gen_var_df)
+
+        assert len(caplog.records) == 0
+
+    # Given an empty dataframe of generators and an empty dataframe of hourly generation for each resource, then no warning is issued.
+    def test_empty_dataframes(self, caplog):
+        gen_df = pd.DataFrame(columns=["Resource"])
+        gen_var_df = pd.DataFrame()
+
+        with caplog.at_level(logging.WARNING):
+            check_vre_profiles(gen_df, gen_var_df)
+
+        assert len(caplog.records) == 0
+
+    # Given a dataframe of generators with a "Resource" column and a dataframe of hourly generation for each resource, when all VRE resources have variable generation profiles, then no warning should be issued.
+    def test_non_variable_vre_profiles_warning(self, caplog):
+        gen_df = pd.DataFrame({"Resource": ["VRE1", "VRE2", "VRE3"], "VRE": [1, 1, 1]})
+        gen_var_df = pd.DataFrame(
+            {"VRE1": [0, 1, 0], "VRE2": [1, 1, 1], "VRE3": [0, 1, 0]}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            check_vre_profiles(gen_df, gen_var_df)
+
+        assert len(caplog.records) == 1
+        assert (
+            "The variable resources ['VRE2'] have non-variable generation profiles."
+            in caplog.records[0].message
+        )
+
+    def test_custom_vre_column(self, caplog):
+        gen_df = pd.DataFrame(
+            {
+                "Resource": ["VRE1", "VRE2", "VRE3"],
+                "VRE": [0, 1, 0],
+                "VRE_STOR": [1, 0, 1],
+            }
+        )
+        gen_var_df = pd.DataFrame(
+            {"VRE1": [0, 1, 0], "VRE2": [1, 1, 1], "VRE3": [0, 1, 0]}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            check_vre_profiles(gen_df, gen_var_df, vre_cols=["VRE", "VRE_STOR"])
+
+        assert len(caplog.records) == 1
+        assert (
+            "The variable resources ['VRE2'] have non-variable generation profiles."
+            in caplog.records[0].message
+        )


### PR DESCRIPTION
Tell the user if profiles that are expected to be variable (VRE and HYDRO tags) are not actually variable.