### PR TITLE
Update how resource tags from settings are applied

### DIFF
--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -15,11 +15,7 @@ from powergenome.external_data import (
     make_generator_variability,
 )
 from powergenome.fuels import fuel_cost_table
-from powergenome.generators import (
-    GeneratorClusters,
-    add_fuel_labels,
-    add_genx_model_tags,
-)
+from powergenome.generators import GeneratorClusters, add_fuel_labels
 from powergenome.GenX import (
     add_cap_res_network,
     add_co2_costs_to_o_m,

--- a/powergenome/util.py
+++ b/powergenome/util.py
@@ -110,6 +110,15 @@ def add_model_tags_to_gen_columns(
     -------
     List[str]
         Updated list of column names, now including any resource tags/columns.
+
+    Example
+    -------
+    >>> model_tag_values = {'cost': {'solar': 100, 'wind': 150}}
+    >>> regional_tag_values = {'NA': {'other_tag': {'solar': 20, 'wind': 25}}}
+    >>> generator_columns = ['capacity', 'output']
+    >>> add_model_tags_to_gen_columns(model_tag_values, regional_tag_values, generator_columns)
+    ['capacity', 'output', 'cost', 'other_tag']
+
     """
 
     if not isinstance(generator_columns, list):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -10,6 +10,7 @@ import pytest
 
 import powergenome
 from powergenome.util import (
+    add_model_tags_to_gen_columns,
     add_row_to_csv,
     apply_all_tag_to_regions,
     assign_model_planning_years,
@@ -355,3 +356,29 @@ class TestAssignModelPlanningYears:
         # Execute function
         with pytest.raises(ValueError):
             assign_model_planning_years(_settings, year)
+
+
+class TestAddModelTagsToGenColumns:
+
+    # Returns the input 'generator_columns' list unmodified if it is not a list.
+    def test_returns_input_unmodified_if_not_list(self):
+        generator_columns = "not a list"
+        model_tag_values = {}
+        regional_tag_values = {}
+        result = add_model_tags_to_gen_columns(
+            model_tag_values, regional_tag_values, generator_columns
+        )
+        assert result == generator_columns
+
+    # Adds model resource tag keys to the 'generator_columns' list if they are not already present.
+    def test_adds_model_tags_to_gen_columns(self):
+        generator_columns = ["capacity", "output"]
+        model_tag_values = {"cost": {"solar": 100, "wind": 150}}
+        regional_tag_values = {"NA": {"efficiency": {"solar": 20, "wind": 25}}}
+        expected_result = ["capacity", "output", "cost", "efficiency"]
+
+        result = add_model_tags_to_gen_columns(
+            model_tag_values, regional_tag_values, generator_columns
+        )
+
+        assert sorted(result) == sorted(expected_result)


### PR DESCRIPTION
Clean up the existing function and fix the bug (#327) where only tags listed in the settings parameter `model_tag_names` are applied.

Also split updating the `generators_columns` settings parameter into a separate function. Add tests for both functions.