### PR TITLE
Directly use demand data

### DIFF
--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -484,7 +484,7 @@ def reduce_time_domain(
 
     else:
         time_index = pd.Series(data=range(1, len(load_profiles) + 1), name="Time_Index")
-        sub_weights = pd.Series(data=[8760], name="Sub_Weights")
+        sub_weights = pd.Series(data=[len(time_index)], name="Sub_Weights")
         hours_per_period = pd.Series(
             data=[len(load_profiles)], name="Timesteps_per_Rep_Period"
         )

--- a/powergenome/cluster/renewables.py
+++ b/powergenome/cluster/renewables.py
@@ -124,8 +124,8 @@ def value_bin(
     return labels
 
 
-@deep_freeze_args
-@lru_cache()
+# @deep_freeze_args
+# @lru_cache()
 def agg_cluster_profile(s: pd.Series, n_clusters: int, **kwargs) -> np.ndarray:
     if len(s) == 0:
         return []
@@ -153,8 +153,8 @@ def agg_cluster_profile(s: pd.Series, n_clusters: int, **kwargs) -> np.ndarray:
     return labels
 
 
-@deep_freeze_args
-@lru_cache()
+# @deep_freeze_args
+# @lru_cache()
 def agg_cluster_other(s: pd.Series, n_clusters: int, **kwargs) -> np.ndarray:
     if len(s) == 0:
         return []
@@ -493,7 +493,14 @@ def assign_site_cluster(
     if min_capacity:
         data = min_capacity_mw(data, min_cap=min_capacity)
     if site_map is not None:
-        site_ids = [site_map.loc[i] for i in data["cpa_id"]]
+        # site_ids = [site_map.loc[i] for i in data["cpa_id"]]
+        missing_site_ids = data.loc[
+            data["cpa_id"].map(site_map).isna(), "cpa_id"
+        ].to_list()
+        if missing_site_ids:
+            print(f"missing site IDs {missing_site_ids}")
+            data = data.loc[~data["cpa_id"].isin(missing_site_ids), :]
+        site_ids = data["cpa_id"].map(site_map).to_list()
     else:
         site_ids = [str(int(i)) for i in data["cpa_id"]]
     if profile_path is not None:

--- a/powergenome/fuels.py
+++ b/powergenome/fuels.py
@@ -11,7 +11,10 @@ from powergenome.eia_opendata import add_user_fuel_prices
 
 
 def fuel_cost_table(
-    fuel_costs: pd.DataFrame, generators: pd.DataFrame, settings: dict
+    fuel_costs: pd.DataFrame,
+    generators: pd.DataFrame,
+    settings: dict,
+    num_hours: int = None,
 ) -> pd.DataFrame:
     """Create a table of fuel costs formatted for the GenX model.
 
@@ -138,7 +141,7 @@ def fuel_cost_table(
         days = settings["time_domain_days_per_period"]
         time_periods = settings["time_domain_periods"]
         num_hours = days * time_periods * 24
-    else:
+    elif num_hours is None:
         num_hours = 8760
 
     fuel_df_prices = pd.DataFrame(

--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -311,20 +311,6 @@ def main(**kwargs):
                     include_retired_cap=first_year is False,
                 )
                 gen_clusters = gc.create_all_generators()
-                if args.fuel and args.gens:
-                    fuels = fuel_cost_table(
-                        fuel_costs=gc.fuel_prices,
-                        generators=gc.all_resources,
-                        settings=_settings,
-                    )
-                    fuels.index.name = "Time_Index"
-                    write_results_file(
-                        df=remove_fuel_scenario_name(fuels, _settings),
-                        folder=case_folder,
-                        file_name="Fuels_data.csv",
-                        include_index=True,
-                        multi_period=args.multi_period,
-                    )
 
                 gen_clusters["Zone"] = gen_clusters["region"].map(zone_num_map)
                 gen_clusters = add_misc_gen_values(gen_clusters, _settings)
@@ -375,6 +361,21 @@ def main(**kwargs):
                     include_index=False,
                     multi_period=args.multi_period,
                 )
+                if args.fuel and args.gens:
+                    fuels = fuel_cost_table(
+                        fuel_costs=gc.fuel_prices,
+                        generators=gc.all_resources,
+                        settings=_settings,
+                        num_hours=len(gen_variability),
+                    )
+                    fuels.index.name = "Time_Index"
+                    write_results_file(
+                        df=remove_fuel_scenario_name(fuels, _settings),
+                        folder=case_folder,
+                        file_name="Fuels_data.csv",
+                        include_index=True,
+                        multi_period=args.multi_period,
+                    )
                 if not args.load:
                     write_results_file(
                         df=gen_variability,
@@ -546,6 +547,7 @@ def main(**kwargs):
                     fuel_costs=gc.fuel_prices,
                     generators=gc.all_resources,
                     settings=_settings,
+                    num_hours=len(gen_variability),
                 )
 
                 fuels.index.name = "Time_Index"

--- a/powergenome/util.py
+++ b/powergenome/util.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Tuple, Union
 
 os.environ["USE_PYGEOS"] = "0"
 
+import duckdb
 import geopandas as gpd
 import pandas as pd
 import pudl
@@ -1465,3 +1466,193 @@ def add_row_to_csv(file: Path, new_row: List[str], headers: List[str] = None) ->
         with file.open("a", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(new_row)  # add the new row to the CSV file
+
+
+def get_all_table_names(data_location: Union[Path, str]) -> List[str]:
+    """
+    Retrieve all table names from the given SQLite or DuckDB database.
+
+    Parameters
+    ----------
+    data_location : str
+        The path to the SQLite or DuckDB database.
+
+    Returns
+    -------
+    List[str]
+        A list of table names in the database.
+    """
+    con = duckdb.connect(database=str(data_location))
+    table_names = con.execute("SHOW TABLES").fetchall()
+    con.close()
+    return [table[0] for table in table_names]
+
+
+def prepend_db_to_tables(
+    query: str, table_names: List[str], db_prefix: str = "db."
+) -> str:
+    """
+    Finds all table names within a query and appends them with the provided db_prefix.
+
+    Parameters
+    ----------
+    query : str
+        The SQL query containing table names.
+    table_names : List[str]
+        A list of table names in the database.
+    db_prefix : str, optional
+        The prefix to prepend to table names. Default is 'db.'.
+
+    Returns
+    -------
+    str
+        The modified query with table names prepended by db_prefix.
+    """
+    for table_name in table_names:
+        # Use regex to find table names not followed by a period
+        query = re.sub(rf"\b{table_name}\b(?!\s*\.)", f"{db_prefix}{table_name}", query)
+    return query
+
+
+def load_data_file(file_path: Union[Path, str]):
+    """
+    Load data from a CSV or Parquet file using duckdb.
+
+    Parameters
+    ----------
+    file_path : Union[Path, str]
+        The path to the CSV or Parquet file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A pandas DataFrame containing the loaded data.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is not supported.
+    """
+    # Create a duckdb connection
+    con = duckdb.connect(database=":memory:")
+
+    # Determine file type and load data
+    file_extension = os.path.splitext(file_path)[1].lower()
+    if file_extension == ".csv":
+        data = con.execute(f"SELECT * FROM read_csv_auto('{file_path}')").fetchdf()
+    elif file_extension == ".parquet":
+        data = con.execute(f"SELECT * FROM read_parquet('{file_path}')").fetchdf()
+    else:
+        con.close()
+        raise ValueError(f"Unsupported file type: {file_extension}")
+
+    con.close()
+    return data
+
+
+def load_table_from_db(
+    data_location: Union[Path, str], file_or_table_name: str = None, query: str = None
+) -> pd.DataFrame:
+    """
+    Load data from a SQLite or DuckDB database using duckdb.
+
+    Parameters
+    ----------
+    data_location : Union[Path, str]
+        The path to the SQLite or DuckDB database.
+    file_or_table_name : str, optional
+        The name of the table to load.
+    query : str, optional
+        The SQL query to run. If provided, the query will be executed instead of selecting from a single table.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A pandas DataFrame containing the loaded data.
+
+    Raises
+    ------
+    ValueError
+        If the database type is not supported.
+    """
+    # Create a duckdb connection
+    con = duckdb.connect(database=":memory:")
+
+    if str(data_location).endswith(".db") or str(data_location).endswith(".sqlite"):
+        con.execute(f"ATTACH '{data_location}' AS db")
+        if query:
+            table_names = get_all_table_names(data_location)
+            query = prepend_db_to_tables(query, table_names)
+            data = con.execute(query).fetchdf()
+        else:
+            query = f"SELECT * FROM db.{file_or_table_name}"
+            data = con.execute(query).fetchdf()
+    elif str(data_location).endswith(".duckdb"):
+        con = duckdb.connect(database=str(data_location))
+        if query:
+            data = con.execute(query).fetchdf()
+        else:
+            query = f"SELECT * FROM {file_or_table_name}"
+            data = con.execute(query).fetchdf()
+    else:
+        con.close()
+        raise ValueError(
+            "Unsupported database type. Use SQLite (.db, .sqlite) or DuckDB (.duckdb)"
+        )
+
+    con.close()
+    return data
+
+
+def load_data(
+    data_location: Union[Path, str], file_or_table_name: str = None, query: str = None
+) -> pd.DataFrame:
+    """
+    Load data from a database or folder of tabular files using duckdb.
+
+    Parameters
+    ----------
+    data_location : str
+        The folder containing CSV or Parquet files, or the name of the SQLite or DuckDB database.
+    file_or_table_name : str, optional
+        The name of the file (with extension .csv or .parquet) or table to load.
+    query : str, optional
+        The SQL query to run if data_location is a database.
+
+    Returns
+    -------
+    pd.DataFrame
+        A pandas DataFrame containing the loaded data.
+
+    Raises
+    ------
+    ValueError
+        If neither file_or_table_name nor query is provided.
+        If file_or_table_name has an extension and data_location is a database.
+        If the specified file is not found in the folder.
+        If an unsupported database type is used.
+    """
+    data_location = Path(data_location)
+    # Validate inputs
+    if not query and not file_or_table_name:
+        raise ValueError("Either file_or_table_name or query must be provided.")
+
+    # Check if data_location is a folder
+    if data_location.is_dir():
+        if file_or_table_name:
+            file_path = data_location / file_or_table_name
+            if not file_path.is_file():
+                raise ValueError(
+                    f"File '{file_or_table_name}' not found in folder '{data_location}'."
+                )
+            return load_data_file(file_path)
+        else:
+            raise ValueError(
+                "file_or_table_name must be provided for loading data from a folder."
+            )
+    else:
+        if file_or_table_name and os.path.splitext(file_or_table_name)[1].lower():
+            raise ValueError(
+                "file_or_table_name should not have an extension when data_location is a database."
+            )
+        return load_table_from_db(data_location, file_or_table_name, query)


### PR DESCRIPTION
Directly use database table demand data in cases where demand data for all planning years is stored in the database, rather than applying growth factors and using stock/demand factors to build future growth.