### PR TITLE
Update fuel label from "None" to "No_fuel" in generator functions and…

### DIFF
--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -1457,7 +1457,7 @@ def filter_empty_columns(df: pd.DataFrame) -> List[str]:
     A column is considered valid if it has at least one value that is:
     - Non-zero
     - Not None (Python None)
-    - Not "None" (string)
+    - Not "No_fuel" (string)
 
     Parameters
     ----------
@@ -1467,14 +1467,14 @@ def filter_empty_columns(df: pd.DataFrame) -> List[str]:
     Returns
     -------
     List[str]
-        List of column names that have at least one non-zero and non-None/"None" value
+        List of column names that have at least one non-zero and non-None/"No_fuel" value
     """
     # Check for non-None values
     notnull_mask = df.notna().sum() > 0
 
-    # Check for non-"None" string values
+    # Check for non-"No_fuel" string values
     string_notnone_mask = (
-        df.applymap(lambda x: str(x) != "None" if pd.notna(x) else False).sum() > 0
+        df.applymap(lambda x: str(x) != "No_fuel" if pd.notna(x) else False).sum() > 0
     )
 
     # Check for non-zero values

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -2258,7 +2258,7 @@ def add_fuel_labels(df, fuel_prices, settings):
     -------
     DataFrame
         Same as input, but with a new column "Fuel" that is either the name of the
-        corresponding fuel (coal, natural_gas, uranium, or distillate) or "None".
+        corresponding fuel (coal, natural_gas, uranium, or distillate) or "No_fuel".
 
     Raises
     ------
@@ -2436,7 +2436,7 @@ def add_fuel_labels(df, fuel_prices, settings):
                     aeo_region, region
                 )
 
-    df.loc[df["Fuel"].isna(), "Fuel"] = "None"
+    df.loc[df["Fuel"].isna(), "Fuel"] = "No_fuel"
 
     return df
 
@@ -3119,7 +3119,7 @@ class GeneratorClusters:
 
         dr_rows = pd.concat(df_list)
         dr_rows["New_Build"] = -1
-        dr_rows["Fuel"] = "None"
+        dr_rows["Fuel"] = "No_fuel"
         dr_rows["cluster"] = 1
         dr_rows = dr_rows.fillna(0)
 

--- a/tests/co2_cost_test.py
+++ b/tests/co2_cost_test.py
@@ -20,7 +20,7 @@ def test_merge_co2_costs():
         "Inv_Cost_per_MWyr": [10, 10000, 10000],
         "Fixed_OM_Cost_per_MWyr": [1, 1000, 1000],
         "Heat_Rate_MMBTU_per_MWh": [5000, 8000, 8000],
-        "Fuel": ["None", "coal", "coal"],
+        "Fuel": ["No_fuel", "coal", "coal"],
     }
     df = pd.DataFrame(data)
     region_aggregations = {"ERCOT": ["ERC_WEST", "ERC_REST"]}
@@ -74,7 +74,7 @@ def test_add_co2_costs_genx():
         "Inv_Cost_per_MWyr": [10, 10000, 10000],
         "Fixed_OM_Cost_per_MWyr": [1, 1000, 1000],
         "Heat_Rate_MMBTU_per_MWh": [5000, 8000, 8000],
-        "Fuel": ["None", "coal", "coal"],
+        "Fuel": ["No_fuel", "coal", "coal"],
     }
     co2_cost_data = {
         "co2_o_m_mw": [0, 2814, 471],

--- a/tests/genx_test.py
+++ b/tests/genx_test.py
@@ -223,8 +223,8 @@ def test_filter_empty_columns():
             "valid_col": [1, 2, 3],
             "zero_col": [0, 0, 0],
             "none_col": [None, None, None],
-            "string_none_col": ["None", "None", "None"],
-            "mixed_col": [1, None, "None"],
+            "string_no_fuel_col": ["No_fuel", "No_fuel", "No_fuel"],
+            "mixed_col": [1, None, "No_fuel"],
             "valid_string": ["a", "b", "c"],
         }
     )
@@ -242,7 +242,7 @@ def test_filter_empty_columns():
         {
             "zero_col": [0, 0],
             "none_col": [None, None],
-            "string_none_col": ["None", "None"],
+            "string_no_fuel_col": ["No_fuel", "No_fuel"],
         }
     )
     assert filter_empty_columns(df_invalid) == [], "All invalid columns case failed"


### PR DESCRIPTION
Change the default "non-fuel" from the string "None" to "No_fuel". This helps get around issues where Pandas recognizes the string "None" as a NaN when reading CSV files.