### PR TITLE
380 tech matching fails when string contains special regex characters

### DIFF
--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -513,7 +513,7 @@ def add_misc_gen_values(
     for tech, _df in misc_values.groupby(resource_col):
         num_tech_regions = len(
             gen_clusters.loc[
-                gen_clusters[resource_col].str.contains(tech, case=False)
+                gen_clusters[resource_col].str.contains(tech, case=False, regex=False)
             ].drop_duplicates(subset=["region"])
         )
         num_values = len(_df)

--- a/powergenome/cluster/renewables.py
+++ b/powergenome/cluster/renewables.py
@@ -703,7 +703,9 @@ def modify_renewable_group(
         # for group, mod in (group_modifiers or {}).items():
         for key, op_list in group_mod.items():
             if isinstance(op_list, float) | isinstance(op_list, int):
-                df.loc[df["cluster"].str.contains(group_id, case=False), key] = op_list
+                df.loc[
+                    df["cluster"].str.contains(group_id, case=False, regex=False), key
+                ] = op_list
             else:
                 if len(op_list) != 2:
                     raise ValueError(
@@ -721,10 +723,13 @@ def modify_renewable_group(
                         "properties of a renewable cluster.\n"
                     )
                 f = operator.attrgetter(op)
-                df.loc[df["cluster"].str.contains(group_id, case=False), key] = f(
-                    operator
-                )(
-                    df.loc[df["cluster"].str.contains(group_id, case=False), key],
+                df.loc[
+                    df["cluster"].str.contains(group_id, case=False, regex=False), key
+                ] = f(operator)(
+                    df.loc[
+                        df["cluster"].str.contains(group_id, case=False, regex=False),
+                        key,
+                    ],
                     op_value,
                 )
     return df

--- a/powergenome/co2_pipeline_cost.py
+++ b/powergenome/co2_pipeline_cost.py
@@ -226,12 +226,18 @@ def mass_to_energy_costs(
     fuel_col = fuel_col[0]
     for fuel, ef in fuel_emission_factors.items():
         df.loc[
-            df[fuel_col].str.contains(fuel, case=False), "tonne_co2_captured_mwh"
+            df[fuel_col].str.contains(fuel, case=False, regex=False),
+            "tonne_co2_captured_mwh",
         ] = (
-            df.loc[df[fuel_col].str.contains(fuel, case=False), heat_rate_col]
+            df.loc[
+                df[fuel_col].str.contains(fuel, case=False, regex=False), heat_rate_col
+            ]
             * ef
             * (
-                df.loc[df[fuel_col].str.contains(fuel, case=False), "capture_rate"]
+                df.loc[
+                    df[fuel_col].str.contains(fuel, case=False, regex=False),
+                    "capture_rate",
+                ]
                 / 100
             )
         )

--- a/powergenome/external_data.py
+++ b/powergenome/external_data.py
@@ -154,7 +154,7 @@ def add_resource_max_cap_spur(
         mask = (new_resource_df["region"] == region) & (
             new_resource_df["technology"]
             .str.replace("_\*", "_all")
-            .str.contains(tech.replace("_\*", "_all"), case=False)
+            .str.contains(tech.replace("_\*", "_all"), case=False, regex=False)
         )
         if mask.sum() > 1:
             resources = new_resource_df.loc[mask, "technology"].to_list()

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -228,7 +228,7 @@ def startup_fuel(df: pd.DataFrame, settings: dict) -> pd.DataFrame:
         for tech in atb_tech:
             df.loc[df["technology"] == tech, "Start_Fuel_MMBTU_per_MW"] = fuel_use
             df.loc[
-                df["technology"].str.contains(tech, case=False),
+                df["technology"].str.contains(tech, case=False, regex=False),
                 "Start_Fuel_MMBTU_per_MW",
             ] = fuel_use
 
@@ -289,7 +289,7 @@ def startup_nonfuel_costs(df: pd.DataFrame, settings: dict) -> pd.DataFrame:
     ).items():
         total_startup_costs = vom_costs[cost_tech] + startup_costs[cost_tech]
         df.loc[
-            df["technology"].str.contains(existing_tech, case=False),
+            df["technology"].str.contains(existing_tech, case=False, regex=False),
             "Start_Cost_per_MW",
         ] = total_startup_costs
 
@@ -1561,7 +1561,7 @@ def add_resource_tags(
                 key=lambda item: len(str(item[0])),
             ):
                 tech = re.sub(ignored, "", tech)
-                mask = technology.str.contains(rf"^{tech}", case=False)
+                mask = technology.str.contains(rf"{tech}", case=False, regex=False)
                 _df.loc[mask, tag_col] = tag_value
         except (KeyError, AttributeError) as e:
             logger.warning(f"No model tag values found for {tag_col} ({e})")
@@ -1572,7 +1572,7 @@ def add_resource_tags(
     for tag_tuple, tag_value in flat_regional_tags.items():
         region, tag_col, tech = tag_tuple
         tech = re.sub(ignored, "", tech)
-        mask = technology.str.contains(rf"^{tech}", case=False)
+        mask = technology.str.contains(rf"{tech}", case=False, regex=False)
         _df.loc[(_df["region"] == region) & mask, tag_col] = tag_value
 
     return _df
@@ -2312,7 +2312,11 @@ def add_fuel_labels(df, fuel_prices, settings):
                     if atb_tech is not None:
                         for tech in atb_tech:
                             df.loc[
-                                (df["technology"].str.contains(tech, case=False))
+                                (
+                                    df["technology"].str.contains(
+                                        tech, case=False, regex=False
+                                    )
+                                )
                                 & (df["region"] == region)
                                 & (df["Fuel"].isna()),
                                 "Fuel",
@@ -2327,7 +2331,11 @@ def add_fuel_labels(df, fuel_prices, settings):
                 if atb_tech is not None:
                     for tech in atb_tech:
                         df.loc[
-                            (df["technology"].str.contains(tech, case=False))
+                            (
+                                df["technology"].str.contains(
+                                    tech, case=False, regex=False
+                                )
+                            )
                             & (df["Fuel"].isna()),
                             "Fuel",
                         ] = fuel
@@ -2342,7 +2350,7 @@ def add_fuel_labels(df, fuel_prices, settings):
                 ), f"{fuel_name} doesn't show up in {model_year}"
 
                 df.loc[
-                    (df["technology"].str.contains(eia_tech, case=False))
+                    (df["technology"].str.contains(eia_tech, case=False, regex=False))
                     & df["region"].isin(model_regions),
                     "Fuel",
                 ] = fuel_name
@@ -2350,7 +2358,11 @@ def add_fuel_labels(df, fuel_prices, settings):
                 if atb_tech is not None:
                     for tech in atb_tech:
                         df.loc[
-                            (df["technology"].str.contains(tech, case=False))
+                            (
+                                df["technology"].str.contains(
+                                    tech, case=False, regex=False
+                                )
+                            )
                             & (df["region"].isin(model_regions))
                             & (df["Fuel"].isna()),
                             "Fuel",
@@ -2373,13 +2385,17 @@ def add_fuel_labels(df, fuel_prices, settings):
                 for region in settings["user_fuel_price"][ccs_base_name].keys():
                     ccs_fuel_name = ("_").join([region, ccs_fuel])
                     df.loc[
-                        (df["technology"].str.contains(ccs_tech, case=False))
+                        (
+                            df["technology"].str.contains(
+                                ccs_tech, case=False, regex=False
+                            )
+                        )
                         & (df["region"] == region),
                         "Fuel",
                     ] = ccs_fuel_name
             else:
                 df.loc[
-                    (df["technology"].str.contains(ccs_tech, case=False)),
+                    (df["technology"].str.contains(ccs_tech, case=False, regex=False)),
                     "Fuel",
                 ] = ccs_fuel
         else:

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -986,6 +986,7 @@ def regional_capex_multiplier(
     tech_map: Dict[str, str],
     regional_multipliers: pd.DataFrame,
 ) -> pd.DataFrame:
+    df = df.copy()
     cost_region = region_map[region]
     tech_multiplier = regional_multipliers.loc[cost_region, :].squeeze()
     avg_multiplier = tech_multiplier.mean()

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -152,7 +152,7 @@ def fetch_atb_costs(
 
         tech_list.append((tech, cost_case))
     tech_names = [t[0] for t in tech_list]
-    if "Battery" not in tech_names:
+    if not any("battery" in tech.lower() for tech in tech_names):
         df = pd.DataFrame(all_rows, columns=col_names)
         wacc_df = pd.DataFrame(
             wacc_rows, columns=["technology", "cost_case", "basis_year", "wacc_real"]
@@ -167,7 +167,7 @@ def fetch_atb_costs(
         """
         atb_techs = [x[0] for x in pg_engine.execute(s).fetchall()]
         battery_wacc_standin = settings.get("atb_battery_wacc")
-        battery_tech = [x for x in techs if x[0] == "Battery"][0]
+        battery_tech = [x for x in techs if "battery" in x[0].lower()][0]
         if isinstance(battery_wacc_standin, float):
             if battery_wacc_standin > 0.1:
                 logger.warning(
@@ -994,9 +994,11 @@ def regional_capex_multiplier(
 
     tech_multiplier_map = {}
     for atb_tech, eia_tech in tech_map.items():
-        if df["technology"].str.contains(atb_tech, case=False).sum() > 0:
+        if df["technology"].str.contains(atb_tech, case=False, regex=False).sum() > 0:
             full_atb_tech = df.loc[
-                df["technology"].str.contains(atb_tech, case=False).idxmax(),
+                df["technology"]
+                .str.contains(atb_tech, case=False, regex=False)
+                .idxmax(),
                 "technology",
             ]
             tech_multiplier_map[full_atb_tech] = tech_multiplier.at[eia_tech]

--- a/tests/generation_test.py
+++ b/tests/generation_test.py
@@ -25,7 +25,7 @@ from powergenome.GenX import (
     round_col_values,
     set_int_cols,
 )
-from powergenome.nrelatb import db_col_values
+from powergenome.nrelatb import db_col_values, regional_capex_multiplier
 
 CWD = Path.cwd()
 # os.environ["RESOURCE_GROUPS"] = str(CWD / "data" / "resource_groups_base")
@@ -1429,3 +1429,120 @@ class TestLabelRetirementYear:
 
         # Check if the original dataframe is returned without any changes
         assert df.equals(labeled_df)
+
+
+class TestRegionalCapexMultiplier:
+    """Test class for regional_capex_multiplier function."""
+
+    @pytest.fixture(scope="class")
+    def sample_data(self):
+        """Create a sample DataFrame with different technology names, including special regex characters."""
+        data = {
+            "technology": ["Solar PV", "Wind*", "Battery+", "CCGT (new)."],
+            "Inv_Cost_per_MWyr": [1000, 2000, 3000, 4000],
+            "Inv_Cost_per_MWhyr": [500, 1000, 1500, 2000],
+        }
+        return pd.DataFrame(data)
+
+    @pytest.fixture(scope="class")
+    def region_map(self):
+        """Create a mapping of regions to cost adjustment regions."""
+        return {"Region1": "CostRegionA", "Region2": "CostRegionB"}
+
+    @pytest.fixture(scope="class")
+    def tech_map(self):
+        """Create a mapping of technology names to their EIA equivalents."""
+        return {
+            "Solar PV": "Solar PV",
+            "Wind*": "Wind",
+            "Battery+": "Battery Storage",
+            "CCGT (new).": "Combined Cycle",
+        }
+
+    @pytest.fixture(scope="class")
+    def regional_multipliers(self):
+        """Create a DataFrame of regional multipliers."""
+        data = {
+            "CostRegionA": {
+                "Solar PV": 1.1,
+                "Wind": 1.2,
+                "Battery Storage": 0.9,
+                "Combined Cycle": 1.05,
+            },
+            "CostRegionB": {
+                "Solar PV": 1.0,
+                "Wind": 1.1,
+                "Battery Storage": 0.95,
+                "Combined Cycle": 1.02,
+            },
+        }
+        return pd.DataFrame(data).T
+
+    def test_regional_capex_multiplier(
+        self, sample_data, region_map, tech_map, regional_multipliers
+    ):
+        """Test that regional multipliers are applied correctly, including for technologies with special regex characters."""
+        region = "Region1"
+        modified_df = regional_capex_multiplier(
+            sample_data, region, region_map, tech_map, regional_multipliers
+        )
+
+        expected_inv_cost = [1000 * 1.1, 2000 * 1.2, 3000 * 0.9, 4000 * 1.05]
+        expected_inv_cost_mwh = [500 * 1.1, 1000 * 1.2, 1500 * 0.9, 2000 * 1.05]
+
+        assert modified_df["Inv_Cost_per_MWyr"].tolist() == pytest.approx(
+            expected_inv_cost, rel=1e-3
+        )
+        assert modified_df["Inv_Cost_per_MWhyr"].tolist() == pytest.approx(
+            expected_inv_cost_mwh, rel=1e-3
+        )
+
+    def test_missing_technology_in_multipliers(self, sample_data, region_map, tech_map):
+        """Test that missing technologies in the multipliers default to the average multiplier."""
+        region = "Region1"
+        # Modify multipliers so "CCGT (new)." is missing
+        regional_multipliers = pd.DataFrame(
+            {
+                "CostRegionA": {
+                    "Solar PV": 1.1,
+                    "Wind": 1.2,
+                    "Battery Storage": 0.9,
+                    "Combined Cycle": np.nan,
+                }
+            }
+        ).T
+
+        modified_df = regional_capex_multiplier(
+            sample_data, region, region_map, tech_map, regional_multipliers
+        )
+
+        # The "CCGT (new)." should use the average multiplier (1.067)
+        avg_multiplier = sum([1.1, 1.2, 0.9]) / 3
+        expected_inv_cost = [1000 * 1.1, 2000 * 1.2, 3000 * 0.9, 4000 * avg_multiplier]
+
+        assert modified_df["Inv_Cost_per_MWyr"].tolist() == pytest.approx(
+            expected_inv_cost, rel=1e-3
+        )
+
+    def test_empty_dataframe(self, region_map, tech_map, regional_multipliers):
+        """Test handling of an empty input DataFrame."""
+        empty_df = pd.DataFrame(
+            columns=["technology", "Inv_Cost_per_MWyr", "Inv_Cost_per_MWhyr"]
+        )
+        region = "Region1"
+
+        modified_df = regional_capex_multiplier(
+            empty_df, region, region_map, tech_map, regional_multipliers
+        )
+        assert modified_df.empty
+
+    def test_invalid_region(
+        self, sample_data, region_map, tech_map, regional_multipliers
+    ):
+        """Test behavior when an invalid region is provided."""
+        invalid_region = "UnknownRegion"
+
+        with pytest.raises(KeyError):
+            regional_capex_multiplier(
+                sample_data, invalid_region, region_map, tech_map, regional_multipliers
+            )

--- a/tests/generation_test.py
+++ b/tests/generation_test.py
@@ -1187,11 +1187,11 @@ class TestAddResourceTags:
     # Given a DataFrame with a 'technology' column, when calling the function with a valid model_tag_values dictionary, then the function should add new columns to the DataFrame with the keys of the model_tag_values dictionary.
     def test_add_resource_tags_with_valid_model_tag_values(self):
         # Create a sample DataFrame
-        df = pd.DataFrame({"technology": ["solar", "wind", "nuclear"]})
+        df = pd.DataFrame({"technology": ["solar", "wind", "nuclear", "gas (h-frame)"]})
 
         # Define the model_tag_values dictionary
         model_tag_values = {
-            "THERM": {"gas": 1, "coal": 2},
+            "THERM": {"nuclear": 1, "coal": 2, "gas (h-frame)": 1},
             "RENEW": {"solar": 1, "wind": 2},
         }
 
@@ -1201,6 +1201,10 @@ class TestAddResourceTags:
         # Check if new columns are added to the DataFrame
         assert "THERM" in result.columns
         assert "RENEW" in result.columns
+
+        # Check if values are filled correctly for each technology
+        assert result["RENEW"].to_list() == [1, 2, 0, 0]
+        assert result["THERM"].to_list() == [0, 0, 1, 1]
 
     # Given a DataFrame without a 'technology' column, when calling the function, then the function should raise a KeyError.
     def test_add_resource_tags_without_technology_column(self):
@@ -1222,18 +1226,21 @@ class TestAddResourceTags:
         # Create a sample DataFrame
         df = pd.DataFrame(
             {
-                "technology": ["solar", "wind", "nuclear"] * 2,
-                "region": ["A"] * 3 + ["B"] * 3,
+                "technology": ["solar", "wind", "nuclear", "gas (h-frame)"] * 2,
+                "region": ["A"] * 4 + ["B"] * 4,
             }
         )
 
         # Define the regional_tag_values dictionary
         regional_tag_values = {
             "A": {
-                "THERM": {"nuclear": 1, "coal": 2},
+                "THERM": {"nuclear": 1, "coal": 2, "gas (h-frame)": 1},
                 "RENEW": {"solar": 1, "wind": 2},
             },
-            "B": {"THERM": {"nuclear": 3, "coal": 4}, "RENEW": {"solar": 3, "wind": 4}},
+            "B": {
+                "THERM": {"nuclear": 3, "coal": 4, "gas (h-frame)": 1},
+                "RENEW": {"solar": 3, "wind": 4},
+            },
         }
 
         # Call the add_resource_tags function
@@ -1244,8 +1251,8 @@ class TestAddResourceTags:
         assert "RENEW" in result.columns
 
         # Check if values are filled correctly for each technology in each region
-        assert result["RENEW"].to_list() == [1, 2, 0, 3, 4, 0]
-        assert result["THERM"].to_list() == [0, 0, 1, 0, 0, 3]
+        assert result["RENEW"].to_list() == [1, 2, 0, 0, 3, 4, 0, 0]
+        assert result["THERM"].to_list() == [0, 0, 1, 1, 0, 0, 3, 1]
 
     # Given a DataFrame with a 'technology' column and a valid regional_tag_values dictionary, but without a 'region' column, when calling the function with the correct arguments, then the function should raise a KeyError.
     def test_add_resource_tags_with_missing_region_column_fixed(self):


### PR DESCRIPTION
- Set `regex=False` within pandas `str.contains` method and remove regex match using "^".
- Update resource tag tests to confirm that string matching works when using a technology with special regex characters (parentheses). 