### PR TITLE
Fix double input folder

### DIFF
--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -225,8 +225,7 @@ def main(**kwargs):
         zone: f"{number + 1}" for zone, number in zip(zones, range(len(zones)))
     }
 
-    input_folder = Path(args.settings_file).parent / Path(settings["input_folder"]).name
-    settings["input_folder"] = input_folder
+    input_folder = settings["input_folder"]
 
     scenario_definitions = pd.read_csv(
         input_folder / settings["scenario_definitions_fn"]

--- a/powergenome/util.py
+++ b/powergenome/util.py
@@ -59,7 +59,7 @@ def load_settings(path: Union[str, Path]) -> dict:
         )
 
     if settings.get("input_folder"):
-        settings["input_folder"] = path.parent / settings["input_folder"]
+        settings["input_folder"] = path.parent / Path(settings["input_folder"]).name
 
     if settings.get("generator_columns"):
         settings["generator_columns"] = add_model_tags_to_gen_columns(


### PR DESCRIPTION
- First commit is necessary because the path is already corrected in load settings, and should not be corrected again afterwards
- Second commit is applying the fix from https://github.com/PowerGenome/PowerGenome/pull/325 to the correction in load settings