### PR TITLE
Allow user generator to have a profile

### DIFF
--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -1643,6 +1643,11 @@ def add_renewables_clusters(
                     **_scenario,
                 )
                 if data.empty:
+                    logger.warning(
+                        f"Site assignment empty for renewables cluster in region {region} "
+                        f"for technology {technology} with profile {resource_groups[0].group.get('profiles')}"
+                        f" and site map {site_map if site_map is None else site_map.name}."
+                    )
                     continue
                 clusters = (
                     data.groupby("cluster", as_index=False)
@@ -1704,6 +1709,12 @@ def add_renewables_clusters(
             clusters.assign(**kwargs).pipe(
                 modify_renewable_group, _scenario.get("group_modifiers")
             )
+        )
+    if len(cdfs) != sum(mask):
+        logger.warning(
+            f"Problem with renewables clustering for region {region}. "
+            f"Expected to create {sum(mask)} clusters, but actually made {len(cdfs)}. "
+            "Check that RESOURCE_GROUPS aligns with your region aggregations."
         )
     return pd.concat([df[~mask]] + cdfs, sort=False)
 

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -2,13 +2,13 @@
 Functions to fetch and modify NREL ATB data from PUDL
 """
 
+import ast
 import collections
 import copy
 import logging
 import operator
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
-import ast
 
 import numpy as np
 import pandas as pd
@@ -1778,10 +1778,9 @@ def load_user_defined_techs(settings: dict) -> pd.DataFrame:
     if "profile" not in user_techs.columns:
         user_techs["profile"] = 0
     else:
-        user_techs['profile'] = user_techs['profile'].apply(
+        user_techs["profile"] = user_techs["profile"].apply(
             lambda x: np.array(ast.literal_eval(x)) if isinstance(x, str) else x
         )
-
 
     if "dollar_year" in user_techs.columns:
         for idx, row in user_techs.iterrows():

--- a/powergenome/nrelatb.py
+++ b/powergenome/nrelatb.py
@@ -8,6 +8,7 @@ import logging
 import operator
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
+import ast
 
 import numpy as np
 import pandas as pd
@@ -1763,6 +1764,13 @@ def load_user_defined_techs(settings: dict) -> pd.DataFrame:
         user_techs["cost_case"] = ""
     if "Cap_Size" not in user_techs.columns:
         user_techs["Cap_Size"] = 1
+    if "profile" not in user_techs.columns:
+        user_techs["profile"] = 0
+    else:
+        user_techs['profile'] = user_techs['profile'].apply(
+            lambda x: np.array(ast.literal_eval(x)) if isinstance(x, str) else x
+        )
+
 
     if "dollar_year" in user_techs.columns:
         for idx, row in user_techs.iterrows():
@@ -1790,6 +1798,7 @@ def load_user_defined_techs(settings: dict) -> pd.DataFrame:
         "heat_rate",
         "Cap_Size",
         "dollar_year",
+        "profile",
     ]
 
     return user_techs[cols]

--- a/powergenome/run_powergenome_multiple_outputs_cli.py
+++ b/powergenome/run_powergenome_multiple_outputs_cli.py
@@ -225,8 +225,7 @@ def main(**kwargs):
         zone: f"{number + 1}" for zone, number in zip(zones, range(len(zones)))
     }
 
-    input_folder = Path(args.settings_file).parent / Path(settings["input_folder"]).name
-    settings["input_folder"] = input_folder
+    input_folder = settings["input_folder"]
 
     scenario_definitions = pd.read_csv(
         input_folder / settings["scenario_definitions_fn"]

--- a/powergenome/util.py
+++ b/powergenome/util.py
@@ -59,7 +59,7 @@ def load_settings(path: Union[str, Path]) -> dict:
         )
 
     if settings.get("input_folder"):
-        settings["input_folder"] = path.parent / settings["input_folder"]
+        settings["input_folder"] = path.parent / Path(settings["input_folder"]).name
 
     if settings.get("generator_columns"):
         settings["generator_columns"] = add_model_tags_to_gen_columns(


### PR DESCRIPTION
- Allows a custom user generator to have a profile column, added by enclosing a comma separated list in quotes so it's read as a single entry in the user generators csv.
- Adds warnings for clustering to partially address #400 
- Merge after #394 since this contains those commits too