### PR TITLE
Simplify capres settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to Semantic Versioning.
 
 ### Added
 
+- Simplified capacity reserve credit specification with `capacity_reserve_values` and auto-expansion. Users can now specify technology credits in a flat format (single constraint) or nested format (multiple constraints) that automatically populate `regional_tag_values`, reducing configuration boilerplate for complex multi-constraint systems. Explicit `regional_tag_values` entries take precedence, allowing mixed automatic and manual specification.
 - weather_year filter support for renewable generation profiles (tidy format). Accepts a single int or a list of ints; when multiple years are provided, profiles are concatenated and a continuous per-site time_index is rebuilt.
 - weather_year filter support for hourly demand profiles. When present, demand is filtered to the requested year and the per-region time_index is rebuilt to be sequential starting at 1.
 - Comprehensive distributed generation (DG) test suite covering capacity interpolation/extrapolation, multi-weather-year profiles, aggregation, timezone shifting, and hourly generation.

--- a/docs/how-to/configure-capacity-reserves.md
+++ b/docs/how-to/configure-capacity-reserves.md
@@ -1,0 +1,248 @@
+# Configure Capacity Reserve Requirements
+
+This guide shows how to specify capacity reserve credit values for different technologies and constraints in PowerGenome. It covers both simple and complex scenarios using the `capacity_reserve_values` and `regional_capacity_reserves` settings.
+
+## Overview
+
+Capacity reserve requirements define how much capacity different technologies contribute to meeting reserve obligations. PowerGenome supports specifying these values in a user-friendly way that automatically populates the underlying `regional_tag_values` structure.
+
+## Basic Setup: Uniform Technology Credits
+
+For systems where technologies get the **same credit values across all capacity reserve constraints**, use the **flat format**:
+
+```yaml
+regional_capacity_reserves:
+  CapRes_1:
+    p1: 0.164
+    p2: 0.164
+    p3: 0.164
+  CapRes_2:
+    p1: 0.090
+    p2: 0.090
+    p3: 0.090
+
+capacity_reserve_values:
+  Conventional Steam Coal: 0.9
+  Natural Gas Fired Combined Cycle: 0.9
+  Onshore Wind Turbine: 0.15
+  Utility Solar Photovoltaic: 0.25
+  Hydroelectric: 1.0
+  Nuclear: 1.0
+```
+
+In this format:
+
+- All technologies listed in `capacity_reserve_values` receive the same credit values
+- These values apply to **all** capacity reserve constraints in `regional_capacity_reserves`
+- Each region gets populated automatically with the technology credits
+
+**Result** (internally):
+
+```yaml
+regional_tag_values:
+  p1:
+    CapRes_1:
+      Conventional Steam Coal: 0.9
+      Natural Gas Fired Combined Cycle: 0.9
+      Onshore Wind Turbine: 0.15
+      Utility Solar Photovoltaic: 0.25
+      Hydroelectric: 1.0
+      Nuclear: 1.0
+    CapRes_2:
+      Conventional Steam Coal: 0.9
+      Natural Gas Fired Combined Cycle: 0.9
+      Onshore Wind Turbine: 0.15
+      Utility Solar Photovoltaic: 0.25
+      Hydroelectric: 1.0
+      Nuclear: 1.0
+  p2:
+    CapRes_1:
+      Conventional Steam Coal: 0.9
+      ...
+    CapRes_2:
+      Conventional Steam Coal: 0.9
+      ...
+  # Similar structure for p3
+```
+
+## Advanced Setup: Multiple Constraints
+
+For systems where technologies have **different credit values depending on the constraint**, use the **nested format**:
+
+```yaml
+regional_capacity_reserves:
+  CapRes_1:
+    p1: 0.164
+    p2: 0.164
+    p3: 0.164
+  CapRes_2:
+    p4: 0.180
+    p5: 0.180
+    p6: 0.180
+  CapRes_3:
+    p1: 0.090
+    p2: 0.090
+    p3: 0.090
+    p4: 0.090
+    p5: 0.090
+    p6: 0.090
+
+capacity_reserve_values:
+  CapRes_1:
+    Conventional Steam Coal: 0.85
+    Natural Gas Fired Combined Cycle: 0.85
+    Onshore Wind Turbine: 0.05
+    Hydroelectric: 1.0
+    Nuclear: 1.0
+  CapRes_2:
+    Conventional Steam Coal: 0.95
+    Natural Gas Fired Combined Cycle: 0.95
+    Onshore Wind Turbine: 0.25
+    Utility Solar Photovoltaic: 0.40
+    Hydroelectric: 1.0
+    Nuclear: 1.0
+  CapRes_3:
+    Conventional Steam Coal: 0.9
+    Natural Gas Fired Combined Cycle: 0.9
+    Onshore Wind Turbine: 0.15
+    Utility Solar Photovoltaic: 0.25
+    Hydroelectric: 1.0
+    Nuclear: 1.0
+```
+
+In this format:
+
+- Each constraint has its own credit values for technologies
+- Constraints can have different requirements in different regions
+- Technologies can have different credits depending on the constraint
+
+**Result** (internally):
+
+```yaml
+regional_tag_values:
+  p1:
+    CapRes_1:
+      Conventional Steam Coal: 0.85
+      Natural Gas Fired Combined Cycle: 0.85
+      ...
+    CapRes_3:
+      Conventional Steam Coal: 0.9
+      ...
+  p4:
+    CapRes_2:
+      Conventional Steam Coal: 0.95
+      ...
+    CapRes_3:
+      Conventional Steam Coal: 0.9
+      ...
+```
+
+## Mixing Automatic and Manual Configuration
+
+You can mix the automatic expansion with manual `regional_tag_values` overrides for specific regions or constraints:
+
+```yaml
+capacity_reserve_values:
+  Tech1: 0.9
+  Tech2: 0.9
+
+regional_capacity_reserves:
+  CapRes_1:
+    p1: 0.164
+    p2: 0.164
+
+# Manual overrides for special cases
+regional_tag_values:
+  p1:
+    CapRes_1:
+      Tech1: 0.95  # Different credit for p1
+```
+
+**Result** (merged):
+
+- `p1/CapRes_1/Tech1`: `0.95` (explicit override)
+- `p1/CapRes_1/Tech2`: `0.9` (auto-expanded)
+- `p2/CapRes_1/Tech1`: `0.9` (auto-expanded)
+- `p2/CapRes_1/Tech2`: `0.9` (auto-expanded)
+
+Explicit entries always take precedence over auto-generated values, allowing you to override specific cells while benefiting from automation elsewhere.
+
+## Scenario-Specific Values
+
+You can use the scenario management system to vary capacity reserve values across different cases:
+
+```yaml
+# Base settings
+capacity_reserve_values:
+  Coal: 0.9
+  Natural Gas: 0.9
+
+settings_management:
+  all_years:
+    reserve_policy:
+      conservative:
+        capacity_reserve_values:
+          Coal: 0.8      # Lower credit in conservative scenario
+          Natural Gas: 0.8
+      aggressive:
+        capacity_reserve_values:
+          Coal: 1.0      # Higher credit in aggressive scenario
+          Natural Gas: 1.0
+```
+
+Then in your scenario definitions file, set `reserve_policy` to `conservative` or `aggressive` for each case. PowerGenome will automatically expand the scenario-specific `capacity_reserve_values` for each case.
+
+## Technology Name Matching
+
+Technology names in `capacity_reserve_values` must match the technology names in your generator data exactly (case-sensitive). Common technology names in PowerGenome include:
+
+- `Conventional Steam Coal`
+- `Natural Gas Fired Combined Cycle`
+- `Natural Gas Fired Combustion Turbine`
+- `Onshore Wind Turbine`
+- `Utility Solar Photovoltaic`
+- `Distributed Solar Photovoltaic`
+- `Hydroelectric`
+- `Nuclear`
+- `Battery Storage`
+
+You can also create custom new-build resources with their own names, which will work with `capacity_reserve_values` as long as the names match.
+
+## Tips and Best Practices
+
+1. **Use the flat format for uniform credits**: If all your technologies have the same credit values across all constraints, the flat format is simpler and easier to maintain.
+
+2. **Use the nested format for varying credits**: If technology credits differ by constraint, use the nested format to specify each constraint separately.
+
+3. **Keep constraint names consistent**: Use the naming scheme `CapRes_1`, `CapRes_2`, `CapRes_3`, etc. and stick with it throughout your settings.
+
+4. **Document constraint meanings**: Add comments explaining what each constraint represents:
+
+   ```yaml
+   regional_capacity_reserves:
+     CapRes_1:  # Primary reserve requirement (MW)
+       p1: 0.164
+   ```
+
+5. **Validate your values**: Ensure technology credit values are between 0 and 1. Values represent the fraction of installed capacity that counts toward the reserve requirement:
+   - `1.0`: Fully counts (e.g., baseload coal, nuclear)
+   - `0.5`: Half credit (e.g., wind, which has low capacity factor)
+   - `0.0`: Zero credit (doesn't contribute)
+
+6. **Use scenario variations for sensitivity analysis**: Explore how reserve policies affect the optimal mix by creating different cases with varying `capacity_reserve_values`.
+
+## Troubleshooting
+
+**Settings not taking effect?**
+
+- Check that `capacity_reserve_values` and `regional_capacity_reserves` are both present in your settings.
+- Verify that technology names match exactly (spaces, capitalization, hyphens).
+- Ensure `model_regions` includes all regions referenced in `regional_capacity_reserves`.
+
+**Different constraints getting same credits unexpectedly?**
+
+- This is the intended flat format behavior. Use nested format if constraints should have different credits per technology.
+
+**Explicit `regional_tag_values` being ignored?**
+
+- Remember that explicit entries in `regional_tag_values` take precedence. If you want automatic values, don't specify them in `regional_tag_values`.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -6,6 +6,7 @@ These guides provide step-by-step instructions for specific tasks. Each guide as
 
 - **[Configure Settings](configure-settings.md)**: Organize settings files, use modular YAML, and manage complex configurations
 - **[Configure Renewable Resource Clusters](configure-renewable-clusters.md)**: Set up wind and solar clusters using filters, bins, groups, and agglomerative or k-means clustering
+- **[Configure Capacity Reserve Requirements](configure-capacity-reserves.md)**: Specify technology credit values for capacity reserve constraints
 - **[Run Multi-Scenario Studies](run-scenarios.md)**: Set up and execute multi-scenario runs with parameter variations
 
 ## Customization
@@ -20,6 +21,7 @@ These guides provide step-by-step instructions for specific tasks. Each guide as
 | Split settings into multiple files | [Configure Settings](configure-settings.md) | Easy |
 | Add a new fuel type | [Add Technologies](add-technologies.md) | Easy |
 | Apply age-based O&M costs | [Modify Generator Attributes](modify-generator-attributes.md) | Easy |
+| Specify capacity reserve credits | [Configure Capacity Reserves](configure-capacity-reserves.md) | Easy |
 | Set up renewable resource clusters | [Configure Renewable Clusters](configure-renewable-clusters.md) | Medium |
 | Run sensitivity analysis | [Run Scenarios](run-scenarios.md) | Medium |
 | Filter renewable sites by LCOE | [Configure Renewable Clusters](configure-renewable-clusters.md) | Medium |

--- a/docs/reference/settings/resource-tags.md
+++ b/docs/reference/settings/resource-tags.md
@@ -271,6 +271,25 @@ regional_tag_values:
 
 Capacity reserve requirements are set in `regional_capacity_reserves`.
 
+!!! info "Simplified Configuration"
+
+    PowerGenome provides a simplified shorthand for specifying capacity reserve credits via `capacity_reserve_values`. Instead of manually building the nested `regional_tag_values` structure shown above, you can use:
+
+    ```yaml
+    capacity_reserve_values:
+      NaturalGas: 0.9
+      Battery: 0.95
+
+    regional_capacity_reserves:
+      CapRes_1:
+        CA_N: 0.164
+        AZ: 0.180
+      CapRes_2:
+        CA_N: 0.090
+    ```
+
+    The system automatically expands this into the `regional_tag_values` structure. See [Configure Capacity Reserve Requirements](../../how-to/configure-capacity-reserves.md) for complete examples and best practices.
+
 ## Tag Validation
 
 PowerGenome validates tag assignments:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
     - Add Custom Technologies: how-to/add-technologies.md
     - Modify Generator Attributes: how-to/modify-generator-attributes.md
     - Configure Renewable Clusters: how-to/configure-renewable-clusters.md
+    - Configure Capacity Reserve Requirements: how-to/configure-capacity-reserves.md
     - Run Multi-Scenario Studies: how-to/run-scenarios.md
 
   - Reference:

--- a/powergenome/settings.py
+++ b/powergenome/settings.py
@@ -662,6 +662,7 @@ def load_settings(path: Union[str, Path]) -> dict:
         )
 
     settings = apply_all_tag_to_regions(settings)
+    settings = expand_capacity_reserve_values(settings)
     settings = sort_nested_dict(settings)
 
     for key in [
@@ -829,6 +830,159 @@ def apply_all_tag_to_regions(settings: dict) -> dict:
                 temp_entry["region"] = reg
 
                 settings["renewables_clusters"].append(temp_entry)
+
+    return settings
+
+
+def expand_capacity_reserve_values(settings: dict) -> dict:
+    """
+    Expand capacity_reserve_values and regional_capacity_reserves into regional_tag_values.
+
+    This function provides a user-friendly shorthand for specifying capacity reserve credit
+    values across multiple regions and constraints. It transforms two settings parameters:
+    - capacity_reserve_values: Technology credit values (flat or nested by constraint)
+    - regional_capacity_reserves: Regional assignments to capacity reserve constraints
+
+    into the standard regional_tag_values structure.
+
+    Parameters
+    ----------
+    settings : dict
+        Settings dictionary containing optional keys:
+        - capacity_reserve_values: Dict of technology values (flat or nested)
+        - regional_capacity_reserves: Dict mapping constraints to regions
+
+    Returns
+    -------
+    dict
+        Modified settings with expanded regional_tag_values. Existing explicit entries
+        in regional_tag_values take precedence over auto-generated ones.
+
+    Notes
+    -----
+    Format auto-detection:
+    - Flat format: All values in capacity_reserve_values are numbers
+      Example: {Tech1: 0.9, Tech2: 0.95}
+      These values are applied to all CapRes_* constraints in regional_capacity_reserves
+
+    - Nested format: Values in capacity_reserve_values are dicts
+      Example: {CapRes_1: {Tech1: 0.9, Tech2: 0.95}, CapRes_2: {...}}
+      Each constraint's values are applied only to that constraint
+
+    Examples
+    --------
+    # Flat format: single capacity reserve constraint
+    settings = {
+        'capacity_reserve_values': {
+            'Conventional Steam Coal': 0.9,
+            'Natural Gas Fired Combined Cycle': 0.9
+        },
+        'regional_capacity_reserves': {
+            'CapRes_1': {'p1': 0.164, 'p2': 0.164}
+        },
+        'model_regions': ['p1', 'p2']
+    }
+    result = expand_capacity_reserve_values(settings)
+    # result['regional_tag_values'] = {
+    #     'p1': {'CapRes_1': {'Conventional Steam Coal': 0.9, ...}},
+    #     'p2': {'CapRes_1': {'Conventional Steam Coal': 0.9, ...}}
+    # }
+
+    # Nested format: multiple capacity reserve constraints
+    settings = {
+        'capacity_reserve_values': {
+            'CapRes_1': {
+                'Conventional Steam Coal': 0.9,
+                'Natural Gas Fired Combined Cycle': 0.9
+            },
+            'CapRes_2': {
+                'Conventional Steam Coal': 0.95,
+                'Natural Gas Fired Combined Cycle': 0.95
+            }
+        },
+        'regional_capacity_reserves': {
+            'CapRes_1': {'p8': 0.164, 'p9': 0.164},
+            'CapRes_2': {'p1': 0.145, 'p2': 0.145}
+        },
+        'model_regions': ['p1', 'p2', 'p8', 'p9']
+    }
+    result = expand_capacity_reserve_values(settings)
+    # result['regional_tag_values'] = {
+    #     'p1': {'CapRes_2': {'Conventional Steam Coal': 0.95, ...}},
+    #     'p2': {'CapRes_2': {'Conventional Steam Coal': 0.95, ...}},
+    #     'p8': {'CapRes_1': {'Conventional Steam Coal': 0.9, ...}},
+    #     'p9': {'CapRes_1': {'Conventional Steam Coal': 0.9, ...}}
+    # }
+    """
+
+    # Get the capacity reserve settings, return early if not present
+    capacity_reserve_values = settings.get("capacity_reserve_values")
+    regional_capacity_reserves = settings.get("regional_capacity_reserves")
+
+    if not capacity_reserve_values or not regional_capacity_reserves:
+        return settings
+
+    # Auto-detect format: flat (all values are numbers) or nested (values are dicts)
+    # Check the first value to determine format
+    first_value = next(iter(capacity_reserve_values.values()), None)
+    is_flat = not isinstance(first_value, dict)
+
+    # Normalize capacity_reserve_values to nested format
+    if is_flat:
+        # Flat format: apply these values to all CapRes_* constraints
+        constraint_names = list(regional_capacity_reserves.keys())
+        normalized_values = {
+            constraint: capacity_reserve_values.copy()
+            for constraint in constraint_names
+        }
+    else:
+        # Already nested
+        normalized_values = capacity_reserve_values
+
+    # Build regional_tag_values from the normalized structure
+    expanded_regional_values = {}
+    for constraint, tech_values in normalized_values.items():
+        # Get regions assigned to this constraint
+        regions_for_constraint = regional_capacity_reserves.get(constraint, {})
+
+        for region in regions_for_constraint.keys():
+            # Ensure region exists in the expanded dict
+            if region not in expanded_regional_values:
+                expanded_regional_values[region] = {}
+
+            # Add this constraint and its technology values for this region
+            expanded_regional_values[region][constraint] = tech_values.copy()
+
+    # Merge with existing regional_tag_values, preserving explicit user entries
+    existing_regional_values = settings.get("regional_tag_values", {})
+
+    # Start with expanded values and layer existing values on top (for full precedence)
+    merged_regional_values = copy.deepcopy(expanded_regional_values)
+
+    # Layer existing values on top, so they take precedence
+    for region, tags in existing_regional_values.items():
+        if region not in merged_regional_values:
+            merged_regional_values[region] = {}
+        # For each constraint in existing values, merge its technology values
+        for constraint, tech_values in tags.items():
+            if constraint not in merged_regional_values[region]:
+                merged_regional_values[region][constraint] = {}
+            # Existing tech values override expanded ones
+            merged_regional_values[region][constraint].update(tech_values)
+
+    # Update settings with the merged regional_tag_values
+    settings["regional_tag_values"] = merged_regional_values
+
+    # Log what was populated
+    regions_populated = set()
+    for constraint, regions in regional_capacity_reserves.items():
+        regions_populated.update(regions.keys())
+
+    if regions_populated:
+        logger.info(
+            f"Expanded capacity_reserve_values into regional_tag_values for "
+            f"regions: {sorted(regions_populated)}"
+        )
 
     return settings
 
@@ -1071,6 +1225,9 @@ def build_scenario_settings(
 
         # make sure model year data appears in standard form
         assign_model_planning_years(_settings, year)
+
+        # expand capacity reserve values into regional_tag_values
+        _settings = expand_capacity_reserve_values(_settings)
 
         scenario_settings.setdefault(year, {})[case_id] = _settings
         if _settings.get("generator_columns"):

--- a/powergenome/settings.py
+++ b/powergenome/settings.py
@@ -922,10 +922,19 @@ def expand_capacity_reserve_values(settings: dict) -> dict:
     if not capacity_reserve_values or not regional_capacity_reserves:
         return settings
 
+    # Validate that all values are consistently dicts or non-dicts
+    values = list(capacity_reserve_values.values())
+    if not values:
+        return settings
+    all_dicts = all(isinstance(v, dict) for v in values)
+    none_dicts = all(not isinstance(v, dict) for v in values)
+    if not (all_dicts or none_dicts):
+        raise ValueError(
+            "All values in 'capacity_reserve_values' must be consistently either dicts (nested format) or non-dicts (flat format). "
+            f"Found mixed types: {[type(v).__name__ for v in values]}"
+        )
     # Auto-detect format: flat (all values are numbers) or nested (values are dicts)
-    # Check the first value to determine format
-    first_value = next(iter(capacity_reserve_values.values()), None)
-    is_flat = not isinstance(first_value, dict)
+    is_flat = none_dicts
 
     # Normalize capacity_reserve_values to nested format
     if is_flat:

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -21,6 +21,7 @@ from powergenome.settings import (
     apply_all_tag_to_regions,
     assign_model_planning_years,
     build_scenario_settings,
+    expand_capacity_reserve_values,
     fix_param_names,
     get_current_settings,
     load_settings,
@@ -1242,3 +1243,332 @@ class TestAutoFillSettings:
             result = test_function()
             assert result["model_year"] == 2035
             assert result["source"] == "context"
+
+
+class TestExpandCapacityReserveValues:
+    """Test the expand_capacity_reserve_values function."""
+
+    def test_flat_format_single_constraint(self):
+        """Test flat format with a single capacity reserve constraint."""
+        settings = {
+            "capacity_reserve_values": {
+                "Conventional Steam Coal": 0.9,
+                "Natural Gas Fired Combined Cycle": 0.9,
+            },
+            "regional_capacity_reserves": {
+                "CapRes_1": {"p1": 0.164, "p2": 0.164, "p3": 0.164},
+            },
+            "model_regions": ["p1", "p2", "p3"],
+            "regional_tag_values": {},
+        }
+
+        result = expand_capacity_reserve_values(settings)
+
+        # Check that all regions have CapRes_1 with correct values
+        assert "regional_tag_values" in result
+        assert "p1" in result["regional_tag_values"]
+        assert "p2" in result["regional_tag_values"]
+        assert "p3" in result["regional_tag_values"]
+
+        # Verify structure and values
+        for region in ["p1", "p2", "p3"]:
+            assert "CapRes_1" in result["regional_tag_values"][region]
+            assert (
+                result["regional_tag_values"][region]["CapRes_1"][
+                    "Conventional Steam Coal"
+                ]
+                == 0.9
+            )
+            assert (
+                result["regional_tag_values"][region]["CapRes_1"][
+                    "Natural Gas Fired Combined Cycle"
+                ]
+                == 0.9
+            )
+
+    def test_nested_format_multiple_constraints(self):
+        """Test nested format with multiple capacity reserve constraints."""
+        settings = {
+            "capacity_reserve_values": {
+                "CapRes_1": {
+                    "Conventional Steam Coal": 0.9,
+                    "Natural Gas Fired Combined Cycle": 0.9,
+                },
+                "CapRes_2": {
+                    "Conventional Steam Coal": 0.95,
+                    "Natural Gas Fired Combined Cycle": 0.95,
+                },
+            },
+            "regional_capacity_reserves": {
+                "CapRes_1": {"p8": 0.164, "p9": 0.164},
+                "CapRes_2": {"p1": 0.145, "p2": 0.145},
+            },
+            "model_regions": ["p1", "p2", "p8", "p9"],
+            "regional_tag_values": {},
+        }
+
+        result = expand_capacity_reserve_values(settings)
+
+        # Check CapRes_1 regions
+        assert (
+            result["regional_tag_values"]["p8"]["CapRes_1"]["Conventional Steam Coal"]
+            == 0.9
+        )
+        assert (
+            result["regional_tag_values"]["p9"]["CapRes_1"]["Conventional Steam Coal"]
+            == 0.9
+        )
+
+        # Check CapRes_2 regions
+        assert (
+            result["regional_tag_values"]["p1"]["CapRes_2"]["Conventional Steam Coal"]
+            == 0.95
+        )
+        assert (
+            result["regional_tag_values"]["p2"]["CapRes_2"]["Conventional Steam Coal"]
+            == 0.95
+        )
+
+        # Ensure no cross-contamination
+        assert "CapRes_2" not in result["regional_tag_values"]["p8"]
+        assert "CapRes_1" not in result["regional_tag_values"]["p1"]
+
+    def test_merge_with_existing_regional_tag_values(self):
+        """Test that existing regional_tag_values are preserved and take precedence."""
+        settings = {
+            "capacity_reserve_values": {
+                "Tech1": 0.9,
+                "Tech2": 0.9,
+            },
+            "regional_capacity_reserves": {
+                "CapRes_1": {"p1": 0.164, "p2": 0.164},
+            },
+            "model_regions": ["p1", "p2"],
+            "regional_tag_values": {
+                "p1": {
+                    "CapRes_1": {
+                        "Tech1": 0.99,  # Override the expanded value
+                    }
+                }
+            },
+        }
+
+        result = expand_capacity_reserve_values(settings)
+
+        # Existing value should override
+        assert result["regional_tag_values"]["p1"]["CapRes_1"]["Tech1"] == 0.99
+        # New value should be added
+        assert result["regional_tag_values"]["p1"]["CapRes_1"]["Tech2"] == 0.9
+        # Other region should get expanded values
+        assert result["regional_tag_values"]["p2"]["CapRes_1"]["Tech1"] == 0.9
+        assert result["regional_tag_values"]["p2"]["CapRes_1"]["Tech2"] == 0.9
+
+    def test_merge_with_other_tags(self):
+        """Test merging with existing tags that are not capacity reserves."""
+        settings = {
+            "capacity_reserve_values": {
+                "Tech1": 0.9,
+            },
+            "regional_capacity_reserves": {
+                "CapRes_1": {"p1": 0.164},
+            },
+            "model_regions": ["p1"],
+            "regional_tag_values": {
+                "p1": {
+                    "OtherTag": {
+                        "Tech1": 0.5,
+                    }
+                }
+            },
+        }
+
+        result = expand_capacity_reserve_values(settings)
+
+        # Both tags should exist
+        assert "OtherTag" in result["regional_tag_values"]["p1"]
+        assert "CapRes_1" in result["regional_tag_values"]["p1"]
+        assert result["regional_tag_values"]["p1"]["OtherTag"]["Tech1"] == 0.5
+        assert result["regional_tag_values"]["p1"]["CapRes_1"]["Tech1"] == 0.9
+
+    def test_no_capacity_reserves_returns_unchanged(self):
+        """Test that settings without capacity reserves are returned unchanged."""
+        settings = {
+            "model_regions": ["p1"],
+            "regional_tag_values": {"p1": {"SomeTag": {}}},
+        }
+
+        result = expand_capacity_reserve_values(settings)
+        assert result == settings
+
+    def test_empty_capacity_reserves_returns_unchanged(self):
+        """Test that settings with empty capacity reserves are returned unchanged."""
+        settings = {
+            "capacity_reserve_values": {},
+            "regional_capacity_reserves": {},
+            "model_regions": ["p1"],
+            "regional_tag_values": {},
+        }
+
+        result = expand_capacity_reserve_values(settings)
+        assert result["regional_tag_values"] == {}
+
+    def test_mixed_format_not_detected(self):
+        """Test that mixed format (some constraint dicts, some values) uses nested interpretation."""
+        settings = {
+            "capacity_reserve_values": {
+                "CapRes_1": {
+                    "Tech1": 0.9,
+                },
+                # Even if this looks like it could be flat, it's nested because CapRes_1 is a dict
+            },
+            "regional_capacity_reserves": {
+                "CapRes_1": {"p1": 0.164},
+            },
+            "model_regions": ["p1"],
+            "regional_tag_values": {},
+        }
+
+        result = expand_capacity_reserve_values(settings)
+        assert result["regional_tag_values"]["p1"]["CapRes_1"]["Tech1"] == 0.9
+
+    def test_preserves_original_settings(self):
+        """Test that the function doesn't mutate the original capacity_reserve_values."""
+        original_capacity_values = {
+            "Tech1": 0.9,
+            "Tech2": 0.8,
+        }
+        capacity_values_copy = original_capacity_values.copy()
+
+        settings = {
+            "capacity_reserve_values": original_capacity_values,
+            "regional_capacity_reserves": {
+                "CapRes_1": {"p1": 0.164},
+            },
+            "model_regions": ["p1"],
+            "regional_tag_values": {},
+        }
+
+        expand_capacity_reserve_values(settings)
+
+        # Original should not be modified
+        assert original_capacity_values == capacity_values_copy
+
+    def test_flat_format_with_three_constraints(self):
+        """Test flat format applied to three different capacity reserve constraints."""
+        settings = {
+            "capacity_reserve_values": {
+                "Nuclear": 1.0,
+                "Coal": 0.8,
+            },
+            "regional_capacity_reserves": {
+                "CapRes_A": {"r1": 0.1, "r2": 0.1},
+                "CapRes_B": {"r3": 0.2},
+                "CapRes_C": {"r4": 0.15, "r5": 0.15},
+            },
+            "model_regions": ["r1", "r2", "r3", "r4", "r5"],
+            "regional_tag_values": {},
+        }
+
+        result = expand_capacity_reserve_values(settings)
+
+        # Verify flat values applied to all constraints
+        for constraint in ["CapRes_A", "CapRes_B", "CapRes_C"]:
+            for region in settings["regional_capacity_reserves"][constraint]:
+                assert (
+                    result["regional_tag_values"][region][constraint]["Nuclear"] == 1.0
+                )
+                assert result["regional_tag_values"][region][constraint]["Coal"] == 0.8
+
+    def test_integration_with_load_settings(self, tmp_path):
+        """Test that expand_capacity_reserve_values is called during load_settings."""
+        settings_file = tmp_path / "settings.yml"
+        settings_content = {
+            "model_regions": ["p1", "p2"],
+            "capacity_reserve_values": {
+                "Tech1": 0.9,
+            },
+            "regional_capacity_reserves": {
+                "CapRes_1": {"p1": 0.164, "p2": 0.164},
+            },
+        }
+
+        with open(settings_file, "w") as f:
+            yaml.dump(settings_content, f)
+
+        result = load_settings(settings_file)
+
+        # Verify capacity reserves were expanded during load
+        assert "regional_tag_values" in result
+        assert "p1" in result["regional_tag_values"]
+        assert "CapRes_1" in result["regional_tag_values"]["p1"]
+        assert result["regional_tag_values"]["p1"]["CapRes_1"]["Tech1"] == 0.9
+
+    def test_integration_with_build_scenario_settings(self, tmp_path):
+        """Test that expand_capacity_reserve_values works in scenario building."""
+        # Create base settings
+        base_settings = {
+            "model_regions": ["p1", "p2"],
+            "model_year": [2030],
+            "model_first_planning_year": [2025],
+            "capacity_reserve_values": {
+                "Tech1": 0.9,
+            },
+            "regional_capacity_reserves": {
+                "CapRes_1": {"p1": 0.164, "p2": 0.164},
+            },
+        }
+
+        # Create scenario definitions
+        scenario_defs = pd.DataFrame(
+            {
+                "case_id": ["case1"],
+                "year": [2030],
+            }
+        )
+
+        result = build_scenario_settings(base_settings, scenario_defs)
+
+        # Verify capacity reserves were expanded in scenario settings
+        case_settings = result[2030]["case1"]
+        assert "regional_tag_values" in case_settings
+        assert "p1" in case_settings["regional_tag_values"]
+        assert "CapRes_1" in case_settings["regional_tag_values"]["p1"]
+
+    def test_scenario_overrides_capacity_reserves(self, tmp_path):
+        """Test that scenario modifications to capacity reserves work correctly."""
+        base_settings = {
+            "model_regions": ["p1", "p2"],
+            "model_year": [2030],
+            "model_first_planning_year": [2025],
+            "capacity_reserve_values": {
+                "Tech1": 0.9,
+            },
+            "regional_capacity_reserves": {
+                "CapRes_1": {"p1": 0.164, "p2": 0.164},
+            },
+            "settings_management": {
+                "all_years": {
+                    "ccs_capex": {
+                        "high": {
+                            "capacity_reserve_values": {
+                                "Tech1": 0.95,  # Override for high CCS scenario
+                            }
+                        }
+                    }
+                }
+            },
+        }
+
+        scenario_defs = pd.DataFrame(
+            {
+                "case_id": ["case_high"],
+                "year": [2030],
+                "ccs_capex": ["high"],
+            }
+        )
+
+        result = build_scenario_settings(base_settings, scenario_defs)
+
+        case_settings = result[2030]["case_high"]
+        # Should use overridden value
+        assert case_settings["regional_tag_values"]["p1"]["CapRes_1"]["Tech1"] == 0.95


### PR DESCRIPTION
Add a `expand_capacity_reserve_values` function to auto-expand the `capacity_reserve_values` settings and `regional_capacity_reserves`parameters into `regional_tag_values` with flat/nested auto-detection and user overrides preserved.

Include tests for the new function and updated documentation showing users how the new system works.