### PR TITLE
Fix plant_region_map_fn to append new plants, not only update existin…

### DIFF
--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -446,9 +446,28 @@ def load_plant_region_map(
 
         user_region_map_df = user_region_map_df.set_index("plant_id_eia")
 
+        # Update region for plants already in the table
         region_map_df.loc[
             region_map_df["plant_id_eia"].isin(user_region_map_df.index), "region"
         ] = region_map_df["plant_id_eia"].map(user_region_map_df["region"])
+
+        # Append rows for plants not already in the table
+        new_plant_ids = user_region_map_df.index.difference(
+            region_map_df["plant_id_eia"]
+        )
+        if not new_plant_ids.empty:
+            new_rows = user_region_map_df.loc[new_plant_ids].reset_index()[
+                ["plant_id_eia", "region"]
+            ]
+            region_map_df = pd.concat(
+                [region_map_df, new_rows], ignore_index=True, sort=False
+            )
+  
+#        user_region_map_df = user_region_map_df.set_index("plant_id_eia")
+#
+#        region_map_df.loc[
+#            region_map_df["plant_id_eia"].isin(user_region_map_df.index), "region"
+#        ] = region_map_df["plant_id_eia"].map(user_region_map_df["region"])
 
     # Label hydro using the IPM shapefile because NEEDS seems to drop some hydro
     all_hydro_regions = label_hydro_region(gens_860, pudl_engine, model_regions_gdf)

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -462,12 +462,12 @@ def load_plant_region_map(
             region_map_df = pd.concat(
                 [region_map_df, new_rows], ignore_index=True, sort=False
             )
-  
-#        user_region_map_df = user_region_map_df.set_index("plant_id_eia")
-#
-#        region_map_df.loc[
-#            region_map_df["plant_id_eia"].isin(user_region_map_df.index), "region"
-#        ] = region_map_df["plant_id_eia"].map(user_region_map_df["region"])
+
+    #        user_region_map_df = user_region_map_df.set_index("plant_id_eia")
+    #
+    #        region_map_df.loc[
+    #            region_map_df["plant_id_eia"].isin(user_region_map_df.index), "region"
+    #        ] = region_map_df["plant_id_eia"].map(user_region_map_df["region"])
 
     # Label hydro using the IPM shapefile because NEEDS seems to drop some hydro
     all_hydro_regions = label_hydro_region(gens_860, pudl_engine, model_regions_gdf)


### PR DESCRIPTION
## Summary
The `plant_region_map_fn` setting allows users to supply a supplemental
CSV to override or add plant-region assignments. However, the current
implementation only updates region assignments for plants already present
in `plant_region_map_epaipm`. Plants in the supplemental file that are
absent from the table are silently ignored.

This means the setting has no effect for plants commissioned after
`pg_misc_tables.sqlite` was built — exactly the plants most likely to
need supplemental assignment.

## Changes
`load_plant_region_map` in generators.py now appends new rows for plants
in the supplemental file that are absent from `plant_region_map_epaipm`,
in addition to updating existing rows.

## Impact
Without this fix, a 26-zone US model using 2024 PUDL data shows only
576 MW of existing solar PV in the PJM Dominion zone. With the fix,
this increases to 5,586 MW — consistent with EIA data showing ~4,700 MW
of Virginia solar commissioned after pg_misc_tables.sqlite was built.
Total existing VRE across the full 26-zone model increases from 160,365 MW
to 326,084 MW when using 2024 data.