### PR TITLE
Fix pandas 2.x/3.x compatibility issues

### DIFF
--- a/powergenome/cluster/renewables.py
+++ b/powergenome/cluster/renewables.py
@@ -466,7 +466,10 @@ def calc_cluster_values(
     profile /= df["weight"].sum()
 
     _df["profile"] = [profile]
-    _df["cluster"] = cluster_label
+    base_cluster = cluster_label
+    if base_cluster is None and "cluster" in df.columns and not df.empty:
+        base_cluster = df["cluster"].iloc[0]
+    _df["cluster"] = base_cluster
     for g in group or []:
         _df["cluster"] = (
             str(_df["cluster"][0]) + f"_{g}_" + str(df[snake_case_str(g)].iloc[0])

--- a/powergenome/cluster/renewables.py
+++ b/powergenome/cluster/renewables.py
@@ -441,6 +441,7 @@ def min_capacity_mw(
 def calc_cluster_values(
     df: pd.DataFrame,
     group: List[str] = None,
+    cluster_label=None,
     sums: List[str] = MERGE["sums"],
     means: List[str] = MERGE["means"],
     weight: str = MERGE["weight"],
@@ -465,7 +466,7 @@ def calc_cluster_values(
     profile /= df["weight"].sum()
 
     _df["profile"] = [profile]
-    _df["cluster"] = df["cluster"].values[0]
+    _df["cluster"] = cluster_label
     for g in group or []:
         _df["cluster"] = (
             str(_df["cluster"][0]) + f"_{g}_" + str(df[snake_case_str(g)].iloc[0])

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -4032,7 +4032,8 @@ class GeneratorClusters:
                 utc_offset=self.settings.get("utc_offset", 0),
                 weather_year=self.settings.get("weather_year"),
             )
-            self.results["profile"][i] = clusters["profile"].iloc[0]
+            row_index = self.results.index[i]
+            self.results.at[row_index, "profile"] = clusters["profile"].iloc[0]
 
         self.results = rename_gen_cols(self.results)
 

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -208,7 +208,7 @@ def startup_fuel(df: pd.DataFrame, settings: dict) -> pd.DataFrame:
     DataFrame
         Modified dataframe with the new column "Start_Fuel_MMBTU_per_MW".
     """
-    df["Start_Fuel_MMBTU_per_MW"] = 0
+    df["Start_Fuel_MMBTU_per_MW"] = 0.0
     for tech, fuel_use in (settings.get("startup_fuel_use") or {}).items():
         df.loc[df["technology"] == tech, "Start_Fuel_MMBTU_per_MW"] = fuel_use
         df.loc[
@@ -272,7 +272,7 @@ def startup_nonfuel_costs(df: pd.DataFrame, settings: dict) -> pd.DataFrame:
                 table_name=settings["dollar_year_table"],
             )
 
-    df["Start_Cost_per_MW"] = 0
+    df["Start_Cost_per_MW"] = 0.0
 
     for existing_tech, cost_tech in settings.get(
         "existing_startup_costs_tech_map", {}
@@ -1566,7 +1566,8 @@ def add_resource_tags(
             "'model_tags_name' but are not assigned values for any resources"
         )
     for tag_col in set(model_tag_names + global_keys + regional_keys):
-        _df.loc[:, tag_col] = default_model_tag
+        _df[tag_col] = default_model_tag
+        _df[tag_col] = _df[tag_col].astype(object)
     for tag_col in global_keys:
         try:
             for tech, tag_value in sorted(
@@ -4031,7 +4032,7 @@ class GeneratorClusters:
                 utc_offset=self.settings.get("utc_offset", 0),
                 weather_year=self.settings.get("weather_year"),
             )
-            self.results["profile"][i] = clusters["profile"][0]
+            self.results["profile"][i] = clusters["profile"].iloc[0]
 
         self.results = rename_gen_cols(self.results)
 

--- a/powergenome/new_build.py
+++ b/powergenome/new_build.py
@@ -1368,8 +1368,10 @@ def add_renewables_clusters(
                 if data.empty:
                     continue
                 clusters = (
-                    data.groupby("cluster", as_index=False)
-                    .apply(calc_cluster_values, _scenario.get("group"))
+                    pd.concat([
+                        calc_cluster_values(grp, _scenario.get("group"), cluster_label=name)
+                        for name, grp in data.groupby("cluster")
+                    ], ignore_index=True)
                     .rename(columns={"capacity_mw": "Max_Cap_MW"})
                     .assign(technology=technology, region=region)
                 )

--- a/powergenome/new_build.py
+++ b/powergenome/new_build.py
@@ -1368,10 +1368,15 @@ def add_renewables_clusters(
                 if data.empty:
                     continue
                 clusters = (
-                    pd.concat([
-                        calc_cluster_values(grp, _scenario.get("group"), cluster_label=name)
-                        for name, grp in data.groupby("cluster")
-                    ], ignore_index=True)
+                    pd.concat(
+                        [
+                            calc_cluster_values(
+                                grp, _scenario.get("group"), cluster_label=name
+                            )
+                            for name, grp in data.groupby("cluster")
+                        ],
+                        ignore_index=True,
+                    )
                     .rename(columns={"capacity_mw": "Max_Cap_MW"})
                     .assign(technology=technology, region=region)
                 )


### PR DESCRIPTION
- Initialize Start_Fuel_MMBTU_per_MW as float (0.0) to avoid int64/float assignment error in startup_fuel()
- Initialize Start_Cost_per_MW as float (0.0) to avoid int64/float assignment error in startup_nonfuel_costs()
- Cast resource tag columns to object dtype in add_resource_tags() to allow mixed int/float/str tag values
- Use .iloc[0] instead of [0] for profile Series access in create_region_technology_clusters()
- Replace groupby.apply() with explicit loop in new_build.py and add cluster_label parameter to calc_cluster_values() to handle pandas 3.x groupby column exclusion behavior

All fixes confirmed working on Python 3.12 / pandas 3.0.1