### PR TITLE
Refactor interconnection capital cost specification

### DIFF
--- a/docs/reference/settings/new-build.md
+++ b/docs/reference/settings/new-build.md
@@ -318,7 +318,7 @@ interconnect_capex_mw:
 
 #### 5. Region -> Technology Nested
 
-Region-specific technology costs (region keys at top level):
+Region-specific technology costs with regions as keys under `by_region_technology`:
 
 ```yaml
 interconnect_capex_mw:

--- a/docs/reference/settings/new-build.md
+++ b/docs/reference/settings/new-build.md
@@ -252,7 +252,7 @@ Flexible specification of per-MW interconnection capital cost (USD/MW) applied t
 
 **Important**: All cost values must be in the same dollar year as `target_usd_year` (the target dollar year for cost normalization). PowerGenome does not automatically adjust interconnection costs for inflation.
 
-**Supported Patterns** (mutually exclusive; `default` key may accompany any pattern):
+**Supported Patterns**:
 
 #### 1. Scalar
 
@@ -262,78 +262,88 @@ Apply uniform cost to all resources:
 interconnect_capex_mw: 150000  # $150k/MW for all resources
 ```
 
-#### 2. Region-Only
+#### 2. Explicit Schema (Recommended)
+
+Use an explicit fallback with typed override blocks:
+
+```yaml
+interconnect_capex_mw:
+  fallback_capex_mw: 110000
+  by_technology:
+    wind: 120000
+    offshore_wind: 200000
+    battery: 50000
+  by_region:
+    CA_N: 125000
+  by_region_technology:
+    CA_N:
+      offshore_wind: 210000
+```
+
+Precedence (most specific to least specific):
+
+1. `by_region_technology`
+2. `by_region`
+3. `by_technology`
+4. `fallback_capex_mw`
+
+#### 3. Region-Only
 
 Different costs by region (exact region name matching):
 
 ```yaml
 interconnect_capex_mw:
-  default: 120000
-  CA_N: 140000
-  CA_S: 130000
-  AZ: 125000
+  fallback_capex_mw: 120000
+  by_region:
+    CA_N: 140000
+    CA_S: 130000
+    AZ: 125000
 ```
 
-#### 3. Technology-Only
+#### 4. Technology-Only
 
 Different costs by technology using case-insensitive substring matching with shortest-first precedence:
 
 ```yaml
 interconnect_capex_mw:
-  default: 100000
-  wind: 120000          # matches 'LandbasedWind_Class3_Moderate', 'OffshoreWind_Class1_Moderate'
-  offshore_wind: 200000 # longer substring overwrites previous 'wind' assignment
-  battery: 50000        # matches 'Battery_4Hr_Moderate', 'Battery_*_Moderate'
-  solar: 110000         # matches 'UtilityPV_Class1_Moderate'
+  fallback_capex_mw: 100000
+  by_technology:
+    wind: 120000          # matches 'LandbasedWind_Class3_Moderate', 'OffshoreWind_Class1_Moderate'
+    offshore_wind: 200000 # longer substring overwrites previous 'wind' assignment
+    battery: 50000        # matches 'Battery_4Hr_Moderate', 'Battery_*_Moderate'
+    solar: 110000         # matches 'UtilityPV_Class1_Moderate'
 ```
 
 **Precedence rule**: Shorter substrings applied first, then longer (more specific) substrings override previous assignments. This allows general categories with specific exceptions.
 
-#### 4. Region → Technology Nested
+#### 5. Region -> Technology Nested
 
 Region-specific technology costs (region keys at top level):
 
 ```yaml
 interconnect_capex_mw:
-  default: 110000
-  CA_N:
-    battery: 60000
-    offshore_wind: 210000
-    solar: 105000
-  CA_S:
-    solar: 95000
-    wind: 115000
-  AZ: 125000  # Can mix dict and numeric values for different regions
+  fallback_capex_mw: 110000
+  by_region_technology:
+    CA_N:
+      battery: 60000
+      offshore_wind: 210000
+      solar: 105000
+    CA_S:
+      solar: 95000
+      wind: 115000
+  by_region:
+    AZ: 125000
 ```
 
 Within each region, technology substrings follow shortest-first precedence.
-
-#### 5. Technology → Region Nested
-
-Technology-specific regional costs (technology keys at top level):
-
-```yaml
-interconnect_capex_mw:
-  default: 110000
-  wind:
-    CA_N: 125000
-    CA_S: 115000
-    AZ: 120000
-  battery:
-    CA_N: 55000
-    CA_S: 52000
-  offshore_wind:
-    CA_N: 205000  # More specific than 'wind', overrides for offshore
-```
-
-Technology substrings applied shortest-first; within each technology, regions matched exactly.
 
 **Matching Rules**:
 
 - **Technology matching**: Case-insensitive substring search against the `technology` column
 - **Substring precedence**: Shortest substrings processed first; longer substrings override
 - **Region matching**: Exact match against model region names (case-sensitive)
-- **Invalid mixing**: Cannot mix region and technology keys at the same top level (excluding `default`)
+- **Explicit schema**: Use only `fallback_capex_mw`, `by_region`, `by_technology`, and `by_region_technology` at the top level.
+- **Invalid mixing**: In legacy syntax, mixing region and technology keys at the same top level is invalid.
 
 **Examples of Invalid Configuration**:
 
@@ -343,6 +353,10 @@ interconnect_capex_mw:
   CA_N: 140000      # Region key
   wind: 120000      # Technology key - mixing not allowed!
 ```
+
+**Legacy Syntax (Deprecated)**:
+
+You may still use the older top-level `default` style for backward compatibility. A deprecation warning is logged at runtime.
 
 **Behavior**:
 
@@ -378,9 +392,10 @@ New approach (recommended):
 
 ```yaml
 interconnect_capex_mw:
-  default: 120000
-  offshore_wind: 200000  # Direct cost specification
-  solar: 105000
+  fallback_capex_mw: 120000
+  by_technology:
+    offshore_wind: 200000  # Direct cost specification
+    solar: 105000
 ```
 
 **Benefits of new system**:

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -2446,8 +2446,8 @@ def _parse_interconnect_capex(
     interconnect_capex_spec: Optional[Union[Number, Dict[str, Any]]],
     resource_df: pd.DataFrame,
 ) -> pd.Series:
-    """Generate a per-resource interconnection capex Series from a flexible
-    ``interconnect_capex_mw`` specification.
+    """Generate a per-resource interconnection capex Series from
+    ``interconnect_capex_mw``.
 
     Preferred explicit dictionary schema:
 
@@ -2463,41 +2463,13 @@ def _parse_interconnect_capex(
     3. ``by_technology``
     4. ``fallback_capex_mw``
 
-    Legacy dictionary patterns are still supported for backward compatibility
-    (using top-level ``default`` and region/technology mixed pattern styles),
-    but are deprecated.
-
-    Legacy patterns (deprecated):
-
-    1. Scalar number
-       <number>
-       Applies uniformly to all rows.
-    2. Region-only
-       {default: <number>, <region>: <number>, ...}
-       All non-default keys must be region names appearing in ``resource_df['region']``.
-    3. Technology-only
-       {default: <number>, <tech_sub>: <number>, ...}
-       All non-default keys are case-insensitive substrings matched against
-       ``resource_df['technology']``. Shortest substrings applied first; longer (more
-       specific) overwrite previous assignments.
-    4. Region -> Technology nested
-       {default: <number>, <region>: {<tech_sub>: <number>, ...}, ...}
-       Region keys map either directly to a number (uniform in that region) or to a
-       dict of technology substrings. Substring precedence (shortest-first) applies
-       within each region. All top-level non-default keys must be region names.
-    5. Technology -> Region nested
-       {default: <number>, <tech_sub>: {<region>: <number>, ...}, ...}
-       Technology substring keys map to dicts keyed by regions assigning values only to
-       rows matching BOTH substring and region. Technology substrings applied
-       shortest-first; region dict order is irrelevant.
-
-    Mixing region names and technology substrings at the same top level (excluding
-    ``default``) is invalid and raises ``ValueError``.
+    A scalar numeric value is still accepted as shorthand and applies uniformly to all
+    rows. Dictionary specifications must use only the explicit keys documented above.
 
     Parameters
     ----------
     interconnect_capex_spec : Optional[Union[Number, Dict[str, Any]]]
-        Specification object or scalar. ``None`` returns zeros.
+        Specification object or scalar shorthand. ``None`` returns zeros.
     resource_df : pd.DataFrame
         Must contain columns ``region`` and ``technology``.
 
@@ -2550,173 +2522,81 @@ def _parse_interconnect_capex(
             match_mask = mask & tech_lower.str.contains(str(sub).lower(), regex=False)
             series.loc[match_mask] = val
 
-    has_explicit_schema_key = any(k in raw for k in explicit_keys)
-    if has_explicit_schema_key:
-        unknown_keys = set(raw.keys()) - explicit_keys
-        if unknown_keys:
-            raise ValueError(
-                "'interconnect_capex_mw' explicit schema only allows keys "
-                "'fallback_capex_mw', 'by_region', 'by_technology', and "
-                "'by_region_technology'. Unknown key(s): "
-                f"{sorted(unknown_keys)}."
-            )
-
-        fallback_val = raw.get("fallback_capex_mw", 0.0)
-        if not isinstance(fallback_val, Number):
-            raise TypeError(
-                "'fallback_capex_mw' value in 'interconnect_capex_mw' must be numeric."
-            )
-
-        by_technology = raw.get("by_technology") or {}
-        by_region = raw.get("by_region") or {}
-        by_region_technology = raw.get("by_region_technology") or {}
-
-        if not isinstance(by_technology, dict):
-            raise TypeError(
-                "'by_technology' in 'interconnect_capex_mw' must be a dict of "
-                "technology substring to numeric value."
-            )
-        if not isinstance(by_region, dict):
-            raise TypeError(
-                "'by_region' in 'interconnect_capex_mw' must be a dict of "
-                "region to numeric value."
-            )
-        if not isinstance(by_region_technology, dict):
-            raise TypeError(
-                "'by_region_technology' in 'interconnect_capex_mw' must be a dict "
-                "of region to dict of technology substrings."
-            )
-
-        validate_numeric_mapping(by_technology, "by_technology")
-        validate_numeric_mapping(by_region, "by_region")
-
-        capex = pd.Series(fallback_val, index=resource_df.index, dtype=float)
-
-        # Apply broad technology overrides first.
-        apply_substring_values(
-            by_technology,
-            pd.Series(True, index=capex.index),
-            capex,
+    unknown_keys = set(raw.keys()) - explicit_keys
+    if unknown_keys:
+        raise ValueError(
+            "'interconnect_capex_mw' explicit schema only allows keys "
+            "'fallback_capex_mw', 'by_region', 'by_technology', and "
+            "'by_region_technology'. Unknown key(s): "
+            f"{sorted(unknown_keys)}."
         )
 
-        # Region-wide overrides are more specific than technology-only overrides.
-        for region_name, val in by_region.items():
-            if region_name not in regions:
-                raise KeyError(
-                    f"In 'interconnect_capex_mw.by_region', region '{region_name}' not present in resource data."
-                )
-            capex.loc[resource_df["region"] == region_name] = val
-
-        # Region + technology is most specific and applied last.
-        for region_name, tech_map in by_region_technology.items():
-            if region_name not in regions:
-                raise KeyError(
-                    "In 'interconnect_capex_mw.by_region_technology', region "
-                    f"'{region_name}' not present in resource data."
-                )
-            if not isinstance(tech_map, dict):
-                raise TypeError(
-                    "Values in 'interconnect_capex_mw.by_region_technology' must be "
-                    f"dicts of technology substrings. Got {tech_map} for region '{region_name}'."
-                )
-            validate_numeric_mapping(
-                tech_map,
-                f"by_region_technology['{region_name}']",
-            )
-            region_mask = resource_df["region"] == region_name
-            apply_substring_values(tech_map, region_mask, capex)
-
-        return capex.fillna(0.0)
-
-    if "default" in raw:
-        logger.warning(
-            "The key 'default' in 'interconnect_capex_mw' is deprecated. "
-            "Use 'fallback_capex_mw' and explicit override blocks "
-            "('by_region', 'by_technology', 'by_region_technology') instead."
+    fallback_val = raw.get("fallback_capex_mw", 0.0)
+    if not isinstance(fallback_val, Number):
+        raise TypeError(
+            "'fallback_capex_mw' value in 'interconnect_capex_mw' must be numeric."
         )
 
-    non_default_items = [(k, v) for k, v in raw.items() if k != "default"]
-    # Empty dict (only default provided)
-    if not non_default_items:
-        default_val = raw.get("default", 0.0)
-        if not isinstance(default_val, Number):
-            raise TypeError(
-                "'default' value in 'interconnect_capex_mw' must be numeric."
-            )
-        return pd.Series(default_val, index=resource_df.index, dtype=float)
+    by_technology = raw.get("by_technology") or {}
+    by_region = raw.get("by_region") or {}
+    by_region_technology = raw.get("by_region_technology") or {}
 
-    all_numbers = all(isinstance(v, Number) for _, v in non_default_items)
+    if not isinstance(by_technology, dict):
+        raise TypeError(
+            "'by_technology' in 'interconnect_capex_mw' must be a dict of "
+            "technology substring to numeric value."
+        )
+    if not isinstance(by_region, dict):
+        raise TypeError(
+            "'by_region' in 'interconnect_capex_mw' must be a dict of "
+            "region to numeric value."
+        )
+    if not isinstance(by_region_technology, dict):
+        raise TypeError(
+            "'by_region_technology' in 'interconnect_capex_mw' must be a dict "
+            "of region to dict of technology substrings."
+        )
 
-    capex = pd.Series(np.nan, index=resource_df.index, dtype=float)
-    default_val = raw.get("default")
-    if default_val is not None:
-        if not isinstance(default_val, Number):
-            raise TypeError(
-                "'default' value in 'interconnect_capex_mw' must be numeric."
-            )
-        capex.loc[:] = default_val
+    validate_numeric_mapping(by_technology, "by_technology")
+    validate_numeric_mapping(by_region, "by_region")
 
-    if all_numbers:
-        keys_region = [k for k, _ in non_default_items if k in regions]
-        if keys_region and len(keys_region) != len(non_default_items):
-            # mixture of region and technology substrings with numeric values
-            raise ValueError(
-                "'interconnect_capex_mw' mixes region and technology keys at the same level."
-            )
-        if keys_region:
-            # Region-only
-            for region_key, val in non_default_items:
-                capex.loc[resource_df["region"] == region_key] = val
-            return capex.fillna(0.0)
-        # Technology-only
-        tech_map = {k: v for k, v in non_default_items}
-        apply_substring_values(tech_map, pd.Series(True, index=capex.index), capex)
-        return capex.fillna(0.0)
+    capex = pd.Series(fallback_val, index=resource_df.index, dtype=float)
 
-    # Nested patterns (values are dict OR numeric in region->tech case)
-    keys_region = [k for k, _ in non_default_items if k in regions]
-
-    # Region -> tech (allow mixture of numeric and dict values) if all top-level keys are region names
-    if keys_region and len(keys_region) == len(non_default_items):
-        for region_key, val in non_default_items:
-            region_mask = resource_df["region"] == region_key
-            if isinstance(val, Number):
-                capex.loc[region_mask] = val
-            elif isinstance(val, dict):
-                # inner tech substrings
-                inner_map = val
-                apply_substring_values(inner_map, region_mask, capex)
-            else:
-                raise TypeError(
-                    f"In 'interconnect_capex_mw', region '{region_key}' value must be numeric or dict of technology substrings. Got {val}."
-                )
-        return capex.fillna(0.0)
-
-    # Technology -> region (all top-level non-default keys NOT regions, each value must be dict of regions)
-    if not keys_region:
-        ordered_top = sorted(non_default_items, key=lambda kv: len(str(kv[0])))
-        for tech_sub, region_map in ordered_top:
-            if not isinstance(region_map, dict):
-                raise TypeError(
-                    f"In 'interconnect_capex_mw', top-level technology substring '{tech_sub}' must map to a dict of regions. Got {region_map}."
-                )
-            tech_mask = tech_lower.str.contains(str(tech_sub).lower(), regex=False)
-            for region_name, val in region_map.items():
-                if region_name not in regions:
-                    raise KeyError(
-                        f"In 'interconnect_capex_mw', region '{region_name}' referenced under technology '{tech_sub}' not present in resource data."
-                    )
-                if not isinstance(val, Number):
-                    raise TypeError(
-                        f"Value in 'interconnect_capex_mw' for region '{region_name}' under technology '{tech_sub}' must be numeric. Got {val}."
-                    )
-                capex.loc[tech_mask & (resource_df["region"] == region_name)] = val
-        return capex.fillna(0.0)
-
-    # If we reached here pattern is invalid (mix of region & tech dicts)
-    raise ValueError(
-        "'interconnect_capex_mw' specification invalid: mixed region and technology keys at top level."
+    # Apply broad technology overrides first.
+    apply_substring_values(
+        by_technology,
+        pd.Series(True, index=capex.index),
+        capex,
     )
+
+    # Region-wide overrides are more specific than technology-only overrides.
+    for region_name, val in by_region.items():
+        if region_name not in regions:
+            raise KeyError(
+                f"In 'interconnect_capex_mw.by_region', region '{region_name}' not present in resource data."
+            )
+        capex.loc[resource_df["region"] == region_name] = val
+
+    # Region + technology is most specific and applied last.
+    for region_name, tech_map in by_region_technology.items():
+        if region_name not in regions:
+            raise KeyError(
+                "In 'interconnect_capex_mw.by_region_technology', region "
+                f"'{region_name}' not present in resource data."
+            )
+        if not isinstance(tech_map, dict):
+            raise TypeError(
+                "Values in 'interconnect_capex_mw.by_region_technology' must be "
+                f"dicts of technology substrings. Got {tech_map} for region '{region_name}'."
+            )
+        validate_numeric_mapping(
+            tech_map,
+            f"by_region_technology['{region_name}']",
+        )
+        region_mask = resource_df["region"] == region_name
+        apply_substring_values(tech_map, region_mask, capex)
+
+    return capex.fillna(0.0)
 
 
 def calculate_transmission_inv_cost(

--- a/powergenome/generators.py
+++ b/powergenome/generators.py
@@ -2449,7 +2449,25 @@ def _parse_interconnect_capex(
     """Generate a per-resource interconnection capex Series from a flexible
     ``interconnect_capex_mw`` specification.
 
-    Supported mutually exclusive top-level patterns (``default`` may accompany any):
+    Preferred explicit dictionary schema:
+
+    - ``fallback_capex_mw``: numeric fallback for any unmatched row
+    - ``by_technology``: ``{<tech_sub>: <number>, ...}``
+    - ``by_region``: ``{<region>: <number>, ...}``
+    - ``by_region_technology``: ``{<region>: {<tech_sub>: <number>, ...}, ...}``
+
+    In the explicit schema, precedence is:
+
+    1. ``by_region_technology``
+    2. ``by_region``
+    3. ``by_technology``
+    4. ``fallback_capex_mw``
+
+    Legacy dictionary patterns are still supported for backward compatibility
+    (using top-level ``default`` and region/technology mixed pattern styles),
+    but are deprecated.
+
+    Legacy patterns (deprecated):
 
     1. Scalar number
        <number>
@@ -2506,15 +2524,19 @@ def _parse_interconnect_capex(
             f"{type(raw)}"
         )
 
-    non_default_items = [(k, v) for k, v in raw.items() if k != "default"]
-    # Empty dict (only default provided)
-    if not non_default_items:
-        default_val = raw.get("default", 0.0)
-        if not isinstance(default_val, Number):
-            raise TypeError(
-                "'default' value in 'interconnect_capex_mw' must be numeric."
-            )
-        return pd.Series(default_val, index=resource_df.index, dtype=float)
+    explicit_keys = {
+        "fallback_capex_mw",
+        "by_region",
+        "by_technology",
+        "by_region_technology",
+    }
+
+    def validate_numeric_mapping(mapping: Dict[str, Any], key_name: str) -> None:
+        for k, v in mapping.items():
+            if not isinstance(v, Number):
+                raise TypeError(
+                    f"Values in '{key_name}' of 'interconnect_capex_mw' must be numeric. Got key '{k}' with value {v}."
+                )
 
     def apply_substring_values(
         mapping: Dict[str, Number], mask: pd.Series, series: pd.Series
@@ -2527,6 +2549,101 @@ def _parse_interconnect_capex(
                 )
             match_mask = mask & tech_lower.str.contains(str(sub).lower(), regex=False)
             series.loc[match_mask] = val
+
+    has_explicit_schema_key = any(k in raw for k in explicit_keys)
+    if has_explicit_schema_key:
+        unknown_keys = set(raw.keys()) - explicit_keys
+        if unknown_keys:
+            raise ValueError(
+                "'interconnect_capex_mw' explicit schema only allows keys "
+                "'fallback_capex_mw', 'by_region', 'by_technology', and "
+                "'by_region_technology'. Unknown key(s): "
+                f"{sorted(unknown_keys)}."
+            )
+
+        fallback_val = raw.get("fallback_capex_mw", 0.0)
+        if not isinstance(fallback_val, Number):
+            raise TypeError(
+                "'fallback_capex_mw' value in 'interconnect_capex_mw' must be numeric."
+            )
+
+        by_technology = raw.get("by_technology") or {}
+        by_region = raw.get("by_region") or {}
+        by_region_technology = raw.get("by_region_technology") or {}
+
+        if not isinstance(by_technology, dict):
+            raise TypeError(
+                "'by_technology' in 'interconnect_capex_mw' must be a dict of "
+                "technology substring to numeric value."
+            )
+        if not isinstance(by_region, dict):
+            raise TypeError(
+                "'by_region' in 'interconnect_capex_mw' must be a dict of "
+                "region to numeric value."
+            )
+        if not isinstance(by_region_technology, dict):
+            raise TypeError(
+                "'by_region_technology' in 'interconnect_capex_mw' must be a dict "
+                "of region to dict of technology substrings."
+            )
+
+        validate_numeric_mapping(by_technology, "by_technology")
+        validate_numeric_mapping(by_region, "by_region")
+
+        capex = pd.Series(fallback_val, index=resource_df.index, dtype=float)
+
+        # Apply broad technology overrides first.
+        apply_substring_values(
+            by_technology,
+            pd.Series(True, index=capex.index),
+            capex,
+        )
+
+        # Region-wide overrides are more specific than technology-only overrides.
+        for region_name, val in by_region.items():
+            if region_name not in regions:
+                raise KeyError(
+                    f"In 'interconnect_capex_mw.by_region', region '{region_name}' not present in resource data."
+                )
+            capex.loc[resource_df["region"] == region_name] = val
+
+        # Region + technology is most specific and applied last.
+        for region_name, tech_map in by_region_technology.items():
+            if region_name not in regions:
+                raise KeyError(
+                    "In 'interconnect_capex_mw.by_region_technology', region "
+                    f"'{region_name}' not present in resource data."
+                )
+            if not isinstance(tech_map, dict):
+                raise TypeError(
+                    "Values in 'interconnect_capex_mw.by_region_technology' must be "
+                    f"dicts of technology substrings. Got {tech_map} for region '{region_name}'."
+                )
+            validate_numeric_mapping(
+                tech_map,
+                f"by_region_technology['{region_name}']",
+            )
+            region_mask = resource_df["region"] == region_name
+            apply_substring_values(tech_map, region_mask, capex)
+
+        return capex.fillna(0.0)
+
+    if "default" in raw:
+        logger.warning(
+            "The key 'default' in 'interconnect_capex_mw' is deprecated. "
+            "Use 'fallback_capex_mw' and explicit override blocks "
+            "('by_region', 'by_technology', 'by_region_technology') instead."
+        )
+
+    non_default_items = [(k, v) for k, v in raw.items() if k != "default"]
+    # Empty dict (only default provided)
+    if not non_default_items:
+        default_val = raw.get("default", 0.0)
+        if not isinstance(default_val, Number):
+            raise TypeError(
+                "'default' value in 'interconnect_capex_mw' must be numeric."
+            )
+        return pd.Series(default_val, index=resource_df.index, dtype=float)
 
     all_numbers = all(isinstance(v, Number) for _, v in non_default_items)
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -198,7 +198,7 @@ def test_calculate_transmission_inv_cost_scalar():
 
 
 def test_calculate_transmission_inv_cost_region_only():
-    spec = {"default": 10000, "A": 20000}
+    spec = {"fallback_capex_mw": 10000, "by_region": {"A": 20000}}
     df = pd.DataFrame(
         {
             "region": ["A", "B"],
@@ -263,7 +263,7 @@ def test_calculate_transmission_inv_cost_explicit_schema_unknown_keys_error():
         calculate_transmission_inv_cost(df.copy(), interconnect_capex_spec=spec)
 
 
-def test_calculate_transmission_inv_cost_legacy_default_warns(caplog):
+def test_calculate_transmission_inv_cost_legacy_default_raises():
     spec = {"default": 10000, "A": 20000}
     df = pd.DataFrame(
         {
@@ -274,16 +274,16 @@ def test_calculate_transmission_inv_cost_legacy_default_warns(caplog):
         }
     )
 
-    caplog.set_level("WARNING", logger="powergenome.generators")
-    out = calculate_transmission_inv_cost(df.copy(), interconnect_capex_spec=spec)
-    assert out.loc[0, "interconnect_capex_mw"] == 20000
-    assert out.loc[1, "interconnect_capex_mw"] == 10000
-    assert "deprecated" in caplog.text.lower()
+    with pytest.raises(ValueError, match="explicit schema only allows keys"):
+        calculate_transmission_inv_cost(df.copy(), interconnect_capex_spec=spec)
 
 
 def test_calculate_transmission_inv_cost_tech_only_precedence():
     # Shortest-first precedence: 'wind' applied first then 'offshore_wind' overwrites matching rows
-    spec = {"default": 10000, "wind": 20000, "offshore_wind": 30000}
+    spec = {
+        "fallback_capex_mw": 10000,
+        "by_technology": {"wind": 20000, "offshore_wind": 30000},
+    }
     df = pd.DataFrame(
         {
             "region": ["A", "A", "A"],
@@ -307,9 +307,11 @@ def test_calculate_transmission_inv_cost_tech_only_precedence():
 
 def test_calculate_transmission_inv_cost_region_to_tech_nested():
     spec = {
-        "default": 8000,
-        "A": {"battery": 6000, "offshore_wind": 25000},
-        "B": {"battery": 7000},
+        "fallback_capex_mw": 8000,
+        "by_region_technology": {
+            "A": {"battery": 6000, "offshore_wind": 25000},
+            "B": {"battery": 7000},
+        },
     }
     df = pd.DataFrame(
         {
@@ -333,11 +335,14 @@ def test_calculate_transmission_inv_cost_region_to_tech_nested():
 
 
 def test_calculate_transmission_inv_cost_tech_to_region_nested():
-    # Top-level default applied first; tech substring region overrides overwrite.
+    # Technology defaults can be refined by region-technology overrides.
     spec = {
-        "default": 5000,
-        "wind": {"A": 15000, "B": 14000},
-        "battery": {"A": 5000, "C": 5500},
+        "fallback_capex_mw": 5000,
+        "by_technology": {"wind": 14000, "battery": 5000},
+        "by_region_technology": {
+            "A": {"wind": 15000},
+            "C": {"battery": 5500},
+        },
     }
     df = pd.DataFrame(
         {
@@ -371,7 +376,7 @@ def test_calculate_transmission_inv_cost_mixed_error():
             "cap_recovery_years": [20],
         }
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="explicit schema only allows keys"):
         calculate_transmission_inv_cost(df.copy(), interconnect_capex_spec=spec)
 
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -217,6 +217,70 @@ def test_calculate_transmission_inv_cost_region_only():
     assert np.isclose(out.loc[1, "interconnect_annuity"], annuity_B)
 
 
+def test_calculate_transmission_inv_cost_explicit_schema_precedence():
+    spec = {
+        "fallback_capex_mw": 9000,
+        "by_technology": {"wind": 20000, "offshore_wind": 30000},
+        "by_region": {"A": 7000},
+        "by_region_technology": {"A": {"offshore_wind": 25000}},
+    }
+    df = pd.DataFrame(
+        {
+            "region": ["A", "A", "B", "C"],
+            "technology": [
+                "offshore_wind_fixed_mid",
+                "battery_storage",
+                "wind_onshore_mid",
+                "solar_pv",
+            ],
+            "wacc_real": [0.05, 0.05, 0.05, 0.05],
+            "cap_recovery_years": [20, 20, 20, 20],
+        }
+    )
+
+    out = calculate_transmission_inv_cost(df.copy(), interconnect_capex_spec=spec)
+    assert out.loc[0, "interconnect_capex_mw"] == 25000
+    assert out.loc[1, "interconnect_capex_mw"] == 7000
+    assert out.loc[2, "interconnect_capex_mw"] == 20000
+    assert out.loc[3, "interconnect_capex_mw"] == 9000
+
+
+def test_calculate_transmission_inv_cost_explicit_schema_unknown_keys_error():
+    spec = {
+        "fallback_capex_mw": 10000,
+        "default": 5000,
+    }
+    df = pd.DataFrame(
+        {
+            "region": ["A"],
+            "technology": ["wind_onshore_mid"],
+            "wacc_real": [0.05],
+            "cap_recovery_years": [20],
+        }
+    )
+
+    with pytest.raises(ValueError, match="explicit schema only allows keys"):
+        calculate_transmission_inv_cost(df.copy(), interconnect_capex_spec=spec)
+
+
+def test_calculate_transmission_inv_cost_legacy_default_warns(caplog):
+    spec = {"default": 10000, "A": 20000}
+    df = pd.DataFrame(
+        {
+            "region": ["A", "B"],
+            "technology": ["solar_pv", "solar_pv"],
+            "wacc_real": [0.05, 0.05],
+            "cap_recovery_years": [25, 25],
+        }
+    )
+
+    caplog.set_level("WARNING", logger="powergenome.generators")
+    out = calculate_transmission_inv_cost(df.copy(), interconnect_capex_spec=spec)
+    assert out.loc[0, "interconnect_capex_mw"] == 20000
+    assert out.loc[1, "interconnect_capex_mw"] == 10000
+    assert "deprecated" in caplog.text.lower()
+
+
 def test_calculate_transmission_inv_cost_tech_only_precedence():
     # Shortest-first precedence: 'wind' applied first then 'offshore_wind' overwrites matching rows
     spec = {"default": 10000, "wind": 20000, "offshore_wind": 30000}

--- a/tests/test_interconnect_capex_errors.py
+++ b/tests/test_interconnect_capex_errors.py
@@ -20,60 +20,84 @@ def test_spec_type_error():
         _parse_interconnect_capex([1, 2, 3], df)
 
 
-# B. Default value not numeric
-def test_default_non_numeric():
+# B. Unknown keys are rejected (legacy dict keys are no longer supported)
+def test_unknown_key_error():
+    df = _make_resource_df()
+    with pytest.raises(ValueError, match="explicit schema only allows keys"):
+        _parse_interconnect_capex({"default": 5}, df)
+
+
+# C. Fallback value must be numeric
+def test_fallback_non_numeric():
     df = _make_resource_df()
     with pytest.raises(TypeError):
-        _parse_interconnect_capex({"default": "x"}, df)
+        _parse_interconnect_capex({"fallback_capex_mw": "x"}, df)
 
 
-# C. Technology-only pattern with non-numeric value
-def test_technology_only_value_non_numeric():
+# D. by_technology must be a dict
+def test_by_technology_must_be_dict():
     df = _make_resource_df()
     with pytest.raises(TypeError):
-        _parse_interconnect_capex({"solar": "high"}, df)
+        _parse_interconnect_capex({"by_technology": 1}, df)
 
 
-# D. Mixing region and technology keys at top level (numeric values)
-def test_mixed_region_tech_numeric_values():
-    df = _make_resource_df()
-    # R1 is a region; 'solar' is a technology substring
-    with pytest.raises(ValueError):
-        _parse_interconnect_capex({"R1": 10, "solar": 20}, df)
-
-
-# E. Region->tech pattern invalid region value type (list)
-def test_region_value_invalid_type():
+# E. by_region must be a dict
+def test_by_region_must_be_dict():
     df = _make_resource_df()
     with pytest.raises(TypeError):
-        _parse_interconnect_capex({"R1": [10], "R2": 5}, df)
+        _parse_interconnect_capex({"by_region": 1}, df)
 
 
-# F. Technology->region pattern with top-level tech substring mapping to non-dict value (list)
-def test_tech_region_non_dict_mapping():
+# F. by_region_technology must be a dict
+def test_by_region_technology_must_be_dict():
     df = _make_resource_df()
-    # Force nested pattern by including at least one dict value so all_numbers is False
     with pytest.raises(TypeError):
-        _parse_interconnect_capex({"solar": {"R1": 5}, "wind": [10]}, df)
+        _parse_interconnect_capex({"by_region_technology": 1}, df)
 
 
-# G. Technology->region mapping referencing missing region
-def test_tech_region_missing_region():
+# G. by_technology values must be numeric
+def test_by_technology_value_non_numeric():
+    df = _make_resource_df()
+    with pytest.raises(TypeError):
+        _parse_interconnect_capex({"by_technology": {"solar": "high"}}, df)
+
+
+# H. by_region values must be numeric
+def test_by_region_value_non_numeric():
+    df = _make_resource_df()
+    with pytest.raises(TypeError):
+        _parse_interconnect_capex({"by_region": {"R1": "five"}}, df)
+
+
+# I. by_region rejects missing regions
+def test_by_region_missing_region():
     df = _make_resource_df()
     with pytest.raises(KeyError):
-        _parse_interconnect_capex({"solar": {"BAD": 5}}, df)
+        _parse_interconnect_capex({"by_region": {"BAD": 5}}, df)
 
 
-# H. Technology->region mapping with non-numeric region value
-def test_tech_region_value_non_numeric():
+# J. by_region_technology entries must be dicts
+def test_by_region_technology_inner_must_be_dict():
     df = _make_resource_df()
     with pytest.raises(TypeError):
-        _parse_interconnect_capex({"solar": {"R1": "five"}}, df)
+        _parse_interconnect_capex({"by_region_technology": {"R1": 5}}, df)
 
 
-# I. Mixed region & technology dict patterns triggering final invalid specification ValueError
-def test_final_invalid_mixed_nested_patterns():
+# K. by_region_technology rejects missing regions
+def test_by_region_technology_missing_region():
     df = _make_resource_df()
-    # Region key 'R1' has dict (region->tech), technology key 'wind' has dict (tech->region)
-    with pytest.raises(ValueError):
-        _parse_interconnect_capex({"R1": {"solar": 10}, "wind": {"R1": 5}}, df)
+    with pytest.raises(KeyError):
+        _parse_interconnect_capex(
+            {"by_region_technology": {"BAD": {"solar": 5}}},
+            df,
+        )
+
+
+# L. by_region_technology values must be numeric
+def test_by_region_technology_value_non_numeric():
+    df = _make_resource_df()
+    with pytest.raises(TypeError):
+        _parse_interconnect_capex(
+            {"by_region_technology": {"R1": {"solar": "five"}}},
+            df,
+        )

--- a/tests/test_system/settings/resources.yml
+++ b/tests/test_system/settings/resources.yml
@@ -174,45 +174,54 @@ new_resources:
 # Method 1: flat rate for all generators
 interconnect_capex_mw: 100000
 
-# Method 2: use a key "default". This can be useful if mixing with other methods.
+# Method 2 (preferred explicit schema): use fallback_capex_mw.
 # interconnect_capex_mw:
-#   default: 100000
+#   fallback_capex_mw: 100000
 
 # Method 3: different rates by region
 # interconnect_capex_mw:
-#   p1_2: 100000
-#   p3: 100000
-#   p4: 100000
+#   fallback_capex_mw: 100000
+#   by_region:
+#     p1_2: 100000
+#     p3: 100000
+#     p4: 100000
 
 # Method 4: different rates by technology (substring match to new_resources)
 # interconnect_capex_mw:
-#   NaturalGas: 100000
-#   Nuclear: 150000
-
-# Method 5: different rates by region and technology, where region is the top-level key
-# interconnect_capex_mw:
-#   p1_2:
+#   fallback_capex_mw: 100000
+#   by_technology:
 #     NaturalGas: 100000
 #     Nuclear: 150000
-#   p3:
-#     NaturalGas: 120000
-#     Nuclear: 170000
-#   p4:
-#     NaturalGas: 110000
-#     Nuclear: 160000
 
-# Method 6: different rates by technology and region, where technology is the top-level key
+# Method 5: region-specific technology overrides
 # interconnect_capex_mw:
-#   NaturalGas:
-#     p1_2: 100000
-#     p3: 120000
-#     p4: 110000
-#   Nuclear:
-#     p1_2: 150000
-#     p3: 170000
-#     p4: 160000
+#   fallback_capex_mw: 100000
+#   by_region_technology:
+#     p1_2:
+#       NaturalGas: 100000
+#       Nuclear: 150000
+#     p3:
+#       NaturalGas: 120000
+#       Nuclear: 170000
+#     p4:
+#       NaturalGas: 110000
+#       Nuclear: 160000
 
-# Combine default with specific overrides
+# Method 6: combine override blocks (precedence: by_region_technology > by_region > by_technology > fallback_capex_mw)
+# interconnect_capex_mw:
+#   fallback_capex_mw: 100000
+#   by_technology:
+#     NaturalGas: 100000
+#     Nuclear: 150000
+#   by_region:
+#     p1_2: 120000
+#   by_region_technology:
+#     p3:
+#       Nuclear: 170000
+#     p4:
+#       NaturalGas: 110000
+
+# Legacy syntax (deprecated): default + mixed top-level patterns
 # interconnect_capex_mw:
 #   default: 100000
 #   p1_2: 120000


### PR DESCRIPTION
This pull request introduces a new, explicit schema for specifying interconnection capital costs per MW in PowerGenome, replacing legacy patterns with a more robust and clear approach. The changes update documentation, implementation, and tests to support and recommend the new schema, which uses `fallback_capex_mw`, `by_technology`, `by_region`, and `by_region_technology` keys with well-defined precedence. Legacy syntax is now deprecated, with warnings and stricter validation for invalid configurations.

**Explicit schema adoption and documentation updates:**

* Documentation (`docs/reference/settings/new-build.md`) now recommends and details the explicit schema for `interconnect_capex_mw`, clarifies precedence rules, and marks legacy syntax as deprecated. Examples and explanations are updated accordingly. [[1]](diffhunk://#diff-295245170012caf472647fa944dabcb9510bbfa5d54a38b4f97a78954153e16eL265-R310) [[2]](diffhunk://#diff-295245170012caf472647fa944dabcb9510bbfa5d54a38b4f97a78954153e16eL292-R346) [[3]](diffhunk://#diff-295245170012caf472647fa944dabcb9510bbfa5d54a38b4f97a78954153e16eR357-R360) [[4]](diffhunk://#diff-295245170012caf472647fa944dabcb9510bbfa5d54a38b4f97a78954153e16eL381-R396)

**Implementation changes for explicit schema:**

* The `_parse_interconnect_capex` function in `powergenome/generators.py` is refactored to support the explicit schema, enforce allowed keys, validate numeric values, apply override precedence, and raise errors for unknown keys. Legacy patterns are still supported but deprecated. [[1]](diffhunk://#diff-a45eccbb4e7a30ab45519af634cdbccd62640c16e3c0a050a11513ea628aecfbL2452-R2470) [[2]](diffhunk://#diff-a45eccbb4e7a30ab45519af634cdbccd62640c16e3c0a050a11513ea628aecfbL2509-L2517) [[3]](diffhunk://#diff-a45eccbb4e7a30ab45519af634cdbccd62640c16e3c0a050a11513ea628aecfbR2553-R2647)

**Testing improvements for new schema and legacy handling:**

* New tests in `tests/test_generators.py` verify correct precedence of explicit schema overrides, error handling for unknown keys, and deprecation warnings for legacy syntax.

**Settings and example updates:**

* Example settings in `tests/test_system/settings/resources.yml` are updated to show the explicit schema usage, clarify override precedence, and distinguish deprecated legacy syntax. [[1]](diffhunk://#diff-aa08dd3ee9f83ad41adbb871e579a004990fce363421ea20b1969f7d36c0fb4eL177-R199) [[2]](diffhunk://#diff-aa08dd3ee9f83ad41adbb871e579a004990fce363421ea20b1969f7d36c0fb4eL204-R224)

**Minor cleanup:**

* Documentation and code comments are updated to clarify supported patterns and remove references to mutually exclusive legacy keys.

These changes modernize and clarify the configuration of interconnection capital costs, improving reliability and maintainability while supporting backward compatibility with clear warnings

Needed to remove "default" key option now that it is used with keyed-year options