### PR TITLE
Validate settings and data

### DIFF
--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -10,6 +10,11 @@ These guides provide step-by-step instructions for specific tasks. Each guide as
 - **[Configure Capacity Reserve Requirements](configure-capacity-reserves.md)**: Specify technology credit values for capacity reserve constraints
 - **[Run Multi-Scenario Studies](run-scenarios.md)**: Set up and execute multi-scenario runs with parameter variations
 
+## Validation and Debugging
+
+- **[Validate Settings Before Running](validate-settings.md)**: Check settings and data for common configuration mistakes before running the pipeline
+- **[Debugging](debugging.md)**: Diagnose and fix common errors
+
 ## Customization
 
 - **[Add Custom Technologies](add-technologies.md)**: Define user technologies, modify standard resources, and configure cost parameters
@@ -27,6 +32,7 @@ These guides provide step-by-step instructions for specific tasks. Each guide as
 | Set up renewable resource clusters | [Configure Renewable Clusters](configure-renewable-clusters.md) | Medium |
 | Run sensitivity analysis | [Run Scenarios](run-scenarios.md) | Medium |
 | Filter renewable sites by LCOE | [Configure Renewable Clusters](configure-renewable-clusters.md) | Medium |
+| Validate settings before a run | [Validate Settings](validate-settings.md) | Easy |
 
 ## Contributing Guides
 

--- a/docs/how-to/validate-settings.md
+++ b/docs/how-to/validate-settings.md
@@ -26,8 +26,10 @@ Validation runs automatically at the start of every `run_powergenome` call, in t
   every fuel/region/year combination you need, and that new-resource cost tables cover
   your planning periods.
 
-If Phase 1 finds **errors**, the pipeline stops before loading any data. Phase 2 issues
-are always **warnings** (the pipeline continues, but results may be wrong).
+If Phase 1 finds **errors**, the pipeline stops before loading any data. Phase 2 can
+produce **warnings** or **errors**: warnings allow the pipeline to continue (though
+results may be wrong), while errors will stop execution when validation is run as part
+of `run_powergenome`.
 
 ---
 
@@ -69,12 +71,10 @@ validate_powergenome --settings_file settings --no-fail
 Each issue is reported with a severity level and a category:
 
 ```
-ERROR    powergenome.validate: [required_keys] Missing required settings key: 'model_regions'
-WARNING  powergenome.validate: [fuel_price_coverage] 2 fuel/scenario/region/year combination(s)
-         are missing from the fuel_price table — missing prices will become $0/MMBtu via fillna(0)
-         Detail:
-         fuel=naturalgas, scenario=reference, region=p5, year=2030
-         fuel=naturalgas, scenario=reference, region=p5, year=2040
+ERROR    powergenome.validate: [ERROR] required_keys: Required settings key 'model_regions' is missing or empty
+WARNING  powergenome.validate: [WARNING] fuel_price_coverage: 2 fuel/scenario/region/year combination(s) are missing from the fuel_price table — missing prices will become $0/MMBtu via fillna(0)
+    Detail: fuel=naturalgas, scenario=reference, region=p5, year=2030
+    fuel=naturalgas, scenario=reference, region=p5, year=2040
 ```
 
 ### Severity levels
@@ -97,7 +97,7 @@ WARNING  powergenome.validate: [fuel_price_coverage] 2 fuel/scenario/region/year
 | `paths` | 1 | `data_location`, `RESOURCE_GROUPS`, `RESOURCE_GROUP_PROFILES`, `input_folder` paths exist |
 | `region_consistency` | 1 | Region-keyed settings (`regional_tag_values`, `alt_num_clusters`, etc.) only reference known `model_regions` |
 | `model_tag_coverage` | 1 | Each entry in `new_resources` matches at least one tag in `model_tag_values` |
-| `fuel_consistency` | 1 | `fuel_scenarios` keys match `fuel_emission_factors` and `tech_fuel_map` entries |
+| `fuel_consistency` | 1 | Fuels in `tech_fuel_map` are defined in `fuel_scenarios`; CCS fuels have capture rates and emission factors |
 | `data_tables` | 2 | Every settings-configured table is present in DataManager |
 | `aggregation_base_regions` | 2 | Every base region in `region_aggregations` and every pass-through in `model_regions` appears in at least one data table |
 | `transmission_regions` | 2 | `transmission_cost_table` only references known model or base regions |
@@ -111,10 +111,8 @@ WARNING  powergenome.validate: [fuel_price_coverage] 2 fuel/scenario/region/year
 ### Region name typo in aggregation
 
 ```
-WARNING  aggregation_base_regions: 1 base region(s) referenced in 'model_regions' or
-         'region_aggregations' do not appear in any data table — check for typos
-         Detail:
-         AZ (aggregation): ['q2']
+WARNING  powergenome.validate: [WARNING] aggregation_base_regions: 1 base region(s) referenced in 'model_regions' or 'region_aggregations' do not appear in any data table (plant_region, demand, fuel_price, transmission_cost) — check for typos
+    Detail: AZ (aggregation): ['q2']
 ```
 
 **Cause**: `region_aggregations` maps `AZ` to `[p1, q2]`, but `q2` doesn't exist in any data table (it was probably meant to be `p2`).
@@ -131,8 +129,10 @@ region_aggregations:
 ### Missing fuel prices
 
 ```
-WARNING  fuel_price_coverage: 3 fuel/scenario/region/year combination(s) are missing
-         from the fuel_price table — missing prices will become $0/MMBtu via fillna(0)
+WARNING  powergenome.validate: [WARNING] fuel_price_coverage: 3 fuel/scenario/region/year combination(s) are missing from the fuel_price table — missing prices will become $0/MMBtu via fillna(0)
+    Detail: fuel=coal, scenario=reference, region=p5, year=2030
+    fuel=naturalgas, scenario=reference, region=p5, year=2030
+    fuel=naturalgas, scenario=reference, region=p5, year=2040
 ```
 
 **Cause**: The fuel price table doesn't have rows for some fuel/region/year combinations needed by the model. The `fuels.fuel_cost_table()` function silently fills missing values with `$0`.
@@ -145,10 +145,8 @@ WARNING  fuel_price_coverage: 3 fuel/scenario/region/year combination(s) are mis
 ### New resource with no planning-period cost data
 
 ```
-WARNING  new_resource_cost_years: 1 new resource/period combination(s) have no matching
-         basis_year in the resource_cost table — costs will be $0 via fillna(0)
-         Detail:
-         OffshoreWind_Class1_Moderate: no basis_year in 2035–2040
+WARNING  powergenome.validate: [WARNING] new_resource_cost_years: 1 new resource/period combination(s) have no matching basis_year in the resource_cost table — costs will be $0 via fillna(0)
+    Detail: OffshoreWind/Class1/Moderate: no basis_year in 2035–2040 (available: [2020, 2025, 2030]…)
 ```
 
 **Cause**: The `resource_cost` table has ATB cost data for some years, but none fall within this planning period's range. `new_build.single_generator_row()` averages over the period window; with no matching rows, the average is `NaN`, which becomes `$0`.
@@ -158,7 +156,7 @@ WARNING  new_resource_cost_years: 1 new resource/period combination(s) have no m
 ### Required key missing
 
 ```
-ERROR  required_keys: Missing required settings key: 'model_regions'
+ERROR    powergenome.validate: [ERROR] required_keys: Required settings key 'model_regions' is missing or empty
 ```
 
 **Fix**: Add the missing key to one of your settings YAML files.

--- a/docs/how-to/validate-settings.md
+++ b/docs/how-to/validate-settings.md
@@ -1,0 +1,165 @@
+# Validate Settings Before Running
+
+PowerGenome includes a built-in validation system that checks your settings and data for common configuration mistakes before they can cause errors or produce silently incorrect results. This guide explains what the checks cover, how to run them, and how to interpret the output.
+
+!!! warning "Validation is not exhaustive"
+    The validation checks catch many common mistakes, but they do not cover every possible
+    configuration error. Always review your output files and logs, especially on the first run
+    with a new configuration.
+
+---
+
+## How validation works
+
+Validation runs automatically at the start of every `run_powergenome` call, in two phases:
+
+**Phase 1 — settings-only checks**
+: Runs before any data files are read. Checks internal consistency of the settings
+  dictionary: required keys are present, paths exist, planning year lists have consistent
+  lengths, region names are consistent across settings parameters, fuel definitions are
+  complete, and new-build resources have the model tags they need.
+
+**Phase 2 — settings vs. data checks**
+: Runs after DataManager has loaded your data tables. Checks that the region names in
+  `region_aggregations` and `model_regions` actually appear in your data, that the
+  transmission cost table doesn't reference unknown regions, that fuel prices exist for
+  every fuel/region/year combination you need, and that new-resource cost tables cover
+  your planning periods.
+
+If Phase 1 finds **errors**, the pipeline stops before loading any data. Phase 2 issues
+are always **warnings** (the pipeline continues, but results may be wrong).
+
+---
+
+## Running validation on its own
+
+To validate your settings without running the full pipeline, use the `validate_powergenome`
+command:
+
+```bash
+validate_powergenome --settings_file path/to/settings
+```
+
+This is useful when:
+
+- You're setting up a new study and want to catch mistakes early
+- You've modified settings and want a quick sanity check before a long run
+- You're debugging unexpected results
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--settings_file SETTINGS_PATH` | Path to your settings folder (required) |
+| `--skip-data-checks` | Only run Phase 1 (no DataManager needed) |
+| `--no-fail` | Log errors but exit with code 0 (useful in CI pipelines) |
+
+```bash
+# Check settings structure only, without loading data files
+validate_powergenome --settings_file settings --skip-data-checks
+
+# Run full validation, don't exit with an error code
+validate_powergenome --settings_file settings --no-fail
+```
+
+---
+
+## Understanding the output
+
+Each issue is reported with a severity level and a category:
+
+```
+ERROR    powergenome.validate: [required_keys] Missing required settings key: 'model_regions'
+WARNING  powergenome.validate: [fuel_price_coverage] 2 fuel/scenario/region/year combination(s)
+         are missing from the fuel_price table — missing prices will become $0/MMBtu via fillna(0)
+         Detail:
+         fuel=naturalgas, scenario=reference, region=p5, year=2030
+         fuel=naturalgas, scenario=reference, region=p5, year=2040
+```
+
+### Severity levels
+
+**ERROR**
+: A definite problem that will cause an exception or clearly wrong results. The pipeline
+  stops (or reports a fatal error). Fix errors before proceeding.
+
+**WARNING**
+: A likely mistake that produces silently incorrect results — for example, a missing fuel
+  price that defaults to $0/MMBtu, or a transmission line that gets dropped without any
+  logged message. Warnings do not stop the pipeline, but should be investigated.
+
+### Categories
+
+| Category | Phase | What it checks |
+|----------|-------|----------------|
+| `required_keys` | 1 | Required settings parameters (`model_regions`, `target_usd_year`, etc.) |
+| `planning_years` | 1 | `model_year` and `model_first_planning_year` have matching lengths; `model_periods` entries are valid 2-element lists |
+| `paths` | 1 | `data_location`, `RESOURCE_GROUPS`, `RESOURCE_GROUP_PROFILES`, `input_folder` paths exist |
+| `region_consistency` | 1 | Region-keyed settings (`regional_tag_values`, `alt_num_clusters`, etc.) only reference known `model_regions` |
+| `model_tag_coverage` | 1 | Each entry in `new_resources` matches at least one tag in `model_tag_values` |
+| `fuel_consistency` | 1 | `fuel_scenarios` keys match `fuel_emission_factors` and `tech_fuel_map` entries |
+| `data_tables` | 2 | Every settings-configured table is present in DataManager |
+| `aggregation_base_regions` | 2 | Every base region in `region_aggregations` and every pass-through in `model_regions` appears in at least one data table |
+| `transmission_regions` | 2 | `transmission_cost_table` only references known model or base regions |
+| `fuel_price_coverage` | 2 | Fuel price table has rows for every fuel/scenario/region/year combination needed |
+| `new_resource_cost_years` | 2 | `resource_cost` table has rows whose `basis_year` overlaps each planning period |
+
+---
+
+## Common issues and fixes
+
+### Region name typo in aggregation
+
+```
+WARNING  aggregation_base_regions: 1 base region(s) referenced in 'model_regions' or
+         'region_aggregations' do not appear in any data table — check for typos
+         Detail:
+         AZ (aggregation): ['q2']
+```
+
+**Cause**: `region_aggregations` maps `AZ` to `[p1, q2]`, but `q2` doesn't exist in any data table (it was probably meant to be `p2`).
+
+**Fix**: Correct the typo in `region_aggregations`:
+
+```yaml
+region_aggregations:
+  AZ:
+    - p1
+    - p2  # was q2
+```
+
+### Missing fuel prices
+
+```
+WARNING  fuel_price_coverage: 3 fuel/scenario/region/year combination(s) are missing
+         from the fuel_price table — missing prices will become $0/MMBtu via fillna(0)
+```
+
+**Cause**: The fuel price table doesn't have rows for some fuel/region/year combinations needed by the model. The `fuels.fuel_cost_table()` function silently fills missing values with `$0`.
+
+**Fix**: Check the `Detail` output to see which combinations are missing, then either:
+
+- Add the missing rows to your fuel price table, or
+- Check that `fuel_scenarios` and `region_aggregations` match the data in your table
+
+### New resource with no planning-period cost data
+
+```
+WARNING  new_resource_cost_years: 1 new resource/period combination(s) have no matching
+         basis_year in the resource_cost table — costs will be $0 via fillna(0)
+         Detail:
+         OffshoreWind_Class1_Moderate: no basis_year in 2035–2040
+```
+
+**Cause**: The `resource_cost` table has ATB cost data for some years, but none fall within this planning period's range. `new_build.single_generator_row()` averages over the period window; with no matching rows, the average is `NaN`, which becomes `$0`.
+
+**Fix**: Extend your cost table to include data for the relevant years, or adjust the `model_periods` planning windows so they overlap with available ATB data years.
+
+### Required key missing
+
+```
+ERROR  required_keys: Missing required settings key: 'model_regions'
+```
+
+**Fix**: Add the missing key to one of your settings YAML files.
+See [Model Definition](../reference/settings/model-definition.md) for a list of required parameters.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,16 +1,23 @@
 # Command Line Interface
 
-PowerGenome provides the `run_powergenome` command for executing the data pipeline.
+PowerGenome provides two commands:
 
-## Basic Usage
+| Command | Purpose |
+|---------|---------|
+| [`run_powergenome`](#run_powergenome) | Execute the full data pipeline and write GenX input files |
+| [`validate_powergenome`](#validate_powergenome) | Check settings and data for configuration mistakes without running the pipeline |
+
+---
+
+## `run_powergenome`
+
+### Basic Usage
 
 ```bash
 run_powergenome --settings_file SETTINGS_PATH --results_folder OUTPUT_PATH
 ```
 
-## Command-Line Flags
-
-### Required Flags
+### Flags
 
 #### `--settings_file` / `-sf`
 
@@ -28,8 +35,6 @@ Directory where output files will be saved. Created if it doesn't exist.
 
 **Type**: String (path)
 **Example**: `--results_folder my_study_outputs`
-
-### Optional Flags
 
 #### `--case_id`
 
@@ -102,9 +107,9 @@ Display help message with all available flags.
 run_powergenome --help
 ```
 
-## Complete Examples
+### Examples
 
-### Basic Run
+#### Basic run
 
 ```bash
 run_powergenome \
@@ -112,7 +117,7 @@ run_powergenome \
     --results_folder my_study/results
 ```
 
-### Run Specific Scenarios
+#### Run specific scenarios
 
 ```bash
 run_powergenome \
@@ -121,7 +126,7 @@ run_powergenome \
     --case_id baseline high_renewable low_cost
 ```
 
-### Greenfield with Sorted Output
+#### Greenfield with sorted output
 
 ```bash
 run_powergenome \
@@ -131,7 +136,7 @@ run_powergenome \
     --sort-gens
 ```
 
-### Debug New Resources Only
+#### Debug new resources only
 
 ```bash
 run_powergenome \
@@ -142,7 +147,7 @@ run_powergenome \
     --verbose
 ```
 
-## Output Organization
+### Output organization
 
 Results are organized by scenario and planning period:
 
@@ -167,7 +172,7 @@ Each scenario folder contains:
 - **Inputs/Inputs_p#/**: GenX input CSV files
 - **log.txt**: Execution log with warnings and info messages
 
-## Exit Codes
+### Exit codes
 
 | Code | Meaning |
 |------|---------|
@@ -175,7 +180,55 @@ Each scenario folder contains:
 | 1 | General error (check log for details) |
 | 2 | Invalid arguments |
 
-## Environment Variables
+---
+
+## `validate_powergenome`
+
+Validates your settings for common configuration mistakes without running the full pipeline.
+See [Validate Settings Before Running](../how-to/validate-settings.md) for a full guide.
+
+### Basic Usage
+
+```bash
+validate_powergenome --settings_file SETTINGS_PATH
+```
+
+### Flags
+
+#### `--settings_file` / `-sf`
+
+**Required.** Path to the folder containing your settings YAML files (same value you pass to `run_powergenome`).
+
+#### `--skip-data-checks`
+
+Only run Phase 1 (settings-only checks). DataManager is not initialized, so no data files need to be present.
+
+**Default**: Both phases run.
+
+```bash
+validate_powergenome -sf settings --skip-data-checks
+```
+
+#### `--no-fail`
+
+Exit with code `0` even when errors are found. Errors are still logged at `ERROR` level. Useful in scripts or CI pipelines where you want to review the output without triggering a failure.
+
+**Default**: Exit with code `1` when any `ERROR`-level issue is found.
+
+```bash
+validate_powergenome -sf settings --no-fail
+```
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No errors found (warnings may still be present) |
+| 1 | One or more `ERROR`-level issues found |
+
+---
+
+## Environment variables
 
 PowerGenome respects these environment variables (legacy, prefer settings YAML):
 
@@ -213,9 +266,9 @@ WARNING:powergenome.generators:Region p5 not found in fuel price data
 INFO:powergenome.GenX:Writing output files to results/case1/Inputs/Inputs_p1/
 ```
 
-## Programmatic Usage
+## Programmatic usage
 
-PowerGenome can also be used programmatically:
+`run_powergenome` can also be called from Python:
 
 ```python
 from powergenome.run_powergenome import main

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
     - Configure Capacity Reserve Requirements: how-to/configure-capacity-reserves.md
     - Run Multi-Scenario Studies: how-to/run-scenarios.md
     - Configure Energy Share Requirements: how-to/energy-share-requirements.md
+    - Validate Settings: how-to/validate-settings.md
     - Debugging: how-to/debugging.md
 
   - Reference:

--- a/powergenome/run_powergenome.py
+++ b/powergenome/run_powergenome.py
@@ -43,6 +43,11 @@ from powergenome.util import (  # init_pudl_connection,; check_settings,; load_i
     write_case_settings_file,
     write_results_file,
 )
+from powergenome.validate import (
+    report_validation_results,
+    validate_settings,
+    validate_settings_with_data,
+)
 
 if not sys.warnoptions:
     import warnings
@@ -169,7 +174,16 @@ def main(**kwargs):
 
     logger.info("Reading settings file")
     settings = Settings(config_path=args.settings_file)
+
+    logger.info("Running Phase 1 settings validation")
+    report_validation_results(validate_settings(settings))
+
     initialize_data_manager(settings, settings["data_location"])
+
+    logger.info("Running Phase 2 data validation")
+    from powergenome.database import _data_manager
+
+    report_validation_results(validate_settings_with_data(settings, _data_manager))
 
     # Copy the settings file to results folder
     if Path(args.settings_file).is_file():

--- a/powergenome/validate.py
+++ b/powergenome/validate.py
@@ -657,6 +657,15 @@ def _check_fuel_price_coverage(settings: dict, dm: Any) -> List[ValidationResult
     if not fuel_scenarios or not model_regions:
         return results
 
+    # Resolve which base regions we need prices for once, rather than inside
+    # the fuel/year loops.
+    base_regions_needed: List[str] = []
+    for region in model_regions:
+        if region in region_aggregations:
+            base_regions_needed.extend(region_aggregations[region])
+        else:
+            base_regions_needed.append(region)
+
     try:
         fuel_df = dm.get_data(
             "fuel_price", columns=["year", "fuel", "region", "scenario"]
@@ -682,28 +691,48 @@ def _check_fuel_price_coverage(settings: dict, dm: Any) -> List[ValidationResult
     has_region_col = "region" in fuel_df.columns
     has_scenario_col = "scenario" in fuel_df.columns
 
+    key_columns: List[str] = ["year"]
+    if has_region_col:
+        key_columns.append("region")
+    if "fuel" in fuel_df.columns:
+        key_columns.append("fuel")
+
+    key_columns_with_scenario = key_columns + ["scenario"] if has_scenario_col else None
+
+    existing_keys = set(
+        fuel_df[key_columns].drop_duplicates().itertuples(index=False, name=None)
+    )
+    existing_keys_with_scenario = (
+        set(
+            fuel_df[key_columns_with_scenario]
+            .drop_duplicates()
+            .itertuples(index=False, name=None)
+        )
+        if key_columns_with_scenario is not None
+        else None
+    )
+
     missing: List[str] = []
     for fuel, scenario in fuel_scenarios.items():
         for model_year in model_years:
-            # Resolve which base regions we need prices for
-            base_regions_needed: List[str] = []
-            for region in model_regions:
-                if region in region_aggregations:
-                    base_regions_needed.extend(region_aggregations[region])
-                else:
-                    base_regions_needed.append(region)
-
             for region in base_regions_needed:
-                mask = fuel_df["year"] == model_year
-                if has_region_col:
-                    mask &= fuel_df["region"] == region
                 if has_scenario_col and scenario:
-                    mask &= fuel_df["scenario"] == scenario
-                # Match on fuel name
-                if "fuel" in fuel_df.columns:
-                    mask &= fuel_df["fuel"] == fuel
+                    expected_key = [model_year]
+                    if has_region_col:
+                        expected_key.append(region)
+                    if "fuel" in fuel_df.columns:
+                        expected_key.append(fuel)
+                    expected_key.append(scenario)
+                    found = tuple(expected_key) in existing_keys_with_scenario
+                else:
+                    expected_key = [model_year]
+                    if has_region_col:
+                        expected_key.append(region)
+                    if "fuel" in fuel_df.columns:
+                        expected_key.append(fuel)
+                    found = tuple(expected_key) in existing_keys
 
-                if not mask.any():
+                if not found:
                     missing.append(
                         f"fuel={fuel}, scenario={scenario}, "
                         f"region={region}, year={model_year}"

--- a/powergenome/validate.py
+++ b/powergenome/validate.py
@@ -1061,6 +1061,55 @@ def report_validation_results(
         )
 
 
+def _print_phase_results(
+    results: List[ValidationResult], phase_name: str
+) -> Tuple[int, int]:
+    """Pretty-print validation results for one phase to stdout.
+
+    Groups ERROR and WARNING results into clearly labelled sections with
+    consistent indentation.  Returns ``(n_errors, n_warnings)``.
+    """
+    errors_ = [r for r in results if r.level == ValidationLevel.ERROR]
+    warnings_ = [r for r in results if r.level == ValidationLevel.WARNING]
+    n_errors, n_warnings = len(errors_), len(warnings_)
+
+    sep = "─" * 64
+    print(f"\n{sep}")
+    print(f"  {phase_name}")
+    print(f"{sep}\n")
+
+    if not results:
+        print("  No issues found.\n")
+        return 0, 0
+
+    if errors_:
+        print("  ERRORS — must be corrected:\n")
+        for r in errors_:
+            print(f"    ✗  [{r.category}]  {r.message}")
+            if r.detail:
+                for line in r.detail.splitlines():
+                    print(f"         {line.strip()}")
+            print()
+
+    if warnings_:
+        print("  WARNINGS — may need to be addressed:\n")
+        for r in warnings_:
+            print(f"    ⚠  [{r.category}]  {r.message}")
+            if r.detail:
+                for line in r.detail.splitlines():
+                    print(f"         {line.strip()}")
+            print()
+
+    summary_parts: List[str] = []
+    if n_errors:
+        summary_parts.append(f"{n_errors} error(s)")
+    if n_warnings:
+        summary_parts.append(f"{n_warnings} warning(s)")
+    print(f"  Result: {', '.join(summary_parts) if summary_parts else 'no issues'}\n")
+
+    return n_errors, n_warnings
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Standalone CLI  (validate_powergenome)
 # ──────────────────────────────────────────────────────────────────────────────
@@ -1127,14 +1176,8 @@ def validate_powergenome() -> None:
 
     logger.info("Running Phase 1 validation (settings-only checks) …")
     p1_results = validate_settings(settings)
-    if p1_results:
-        report_validation_results(p1_results, raise_on_error=False)
-        has_errors = any(r.level == ValidationLevel.ERROR for r in p1_results)
-        p1_warns = sum(r.level == ValidationLevel.WARNING for r in p1_results)
-        p1_errs = sum(r.level == ValidationLevel.ERROR for r in p1_results)
-        logger.info("Phase 1 complete: %d error(s), %d warning(s)", p1_errs, p1_warns)
-    else:
-        logger.info("Phase 1 complete: no issues found.")
+    p1_errs, _ = _print_phase_results(p1_results, "Phase 1: Settings checks")
+    has_errors = p1_errs > 0
 
     # ── Phase 2 ────────────────────────────────────────────────────────────────
     if not args.skip_data_checks:
@@ -1150,22 +1193,8 @@ def validate_powergenome() -> None:
             try:
                 initialize_data_manager(settings, data_location)
                 p2_results = validate_settings_with_data(settings, _data_manager)
-                if p2_results:
-                    report_validation_results(p2_results, raise_on_error=False)
-                    has_errors = has_errors or any(
-                        r.level == ValidationLevel.ERROR for r in p2_results
-                    )
-                    p2_warns = sum(
-                        r.level == ValidationLevel.WARNING for r in p2_results
-                    )
-                    p2_errs = sum(r.level == ValidationLevel.ERROR for r in p2_results)
-                    logger.info(
-                        "Phase 2 complete: %d error(s), %d warning(s)",
-                        p2_errs,
-                        p2_warns,
-                    )
-                else:
-                    logger.info("Phase 2 complete: no issues found.")
+                p2_errs, _ = _print_phase_results(p2_results, "Phase 2: Data checks")
+                has_errors = has_errors or p2_errs > 0
             except Exception as exc:
                 logger.error("Phase 2 validation failed unexpectedly: %s", exc)
                 has_errors = True

--- a/powergenome/validate.py
+++ b/powergenome/validate.py
@@ -1,0 +1,1158 @@
+"""
+Settings and data validation for PowerGenome.
+
+Provides two-phase validation:
+
+  Phase 1 (``validate_settings``):
+    Settings internal consistency — region keys, required keys, path existence,
+    planning year definitions, fuel definitions, and model tag coverage.
+    Runs without any data file access.
+
+  Phase 2 (``validate_settings_with_data``):
+    Settings vs. loaded data — fuel price coverage, new-resource cost year
+    overlap, and transmission region consistency.
+    Requires a fully initialized ``DataManager``.
+
+Severity levels
+---------------
+ERROR
+    Definite failures that will cause exceptions or produce completely wrong
+    results (e.g. missing required settings keys, non-existent paths).
+WARNING
+    Likely mistakes that produce silently incorrect results (e.g. a $0 fuel
+    price due to a missing table entry, or a transmission line that will be
+    dropped without any logged message).
+
+Example
+-------
+::
+
+    from powergenome.settings import Settings
+    from powergenome.database import initialize_data_manager
+    from powergenome.validate import (
+        validate_settings,
+        validate_settings_with_data,
+        report_validation_results,
+    )
+
+    settings = Settings(config_path="my_study/settings")
+
+    # Phase 1 — no DataManager needed
+    results = validate_settings(settings)
+    report_validation_results(results)          # raises if any ERRORs
+
+    initialize_data_manager(settings, settings["data_location"])
+
+    # Phase 2 — requires initialised DataManager
+    from powergenome.database import _data_manager
+    results2 = validate_settings_with_data(settings, _data_manager)
+    report_validation_results(results2)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Core types
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class ValidationLevel(str, Enum):
+    ERROR = "ERROR"
+    WARNING = "WARNING"
+
+
+@dataclass
+class ValidationResult:
+    level: ValidationLevel
+    category: str
+    message: str
+    detail: Optional[str] = None
+
+    def __str__(self) -> str:
+        detail_str = f"\n    Detail: {self.detail}" if self.detail else ""
+        return f"[{self.level.value}] {self.category}: {self.message}{detail_str}"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Internal helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Tags that every resource must carry at least one of in the final GenX output.
+_REQUIRED_TAGS = frozenset({"THERM", "VRE", "MUST_RUN", "STOR", "FLEX", "HYDRO"})
+
+
+def _err(category: str, message: str, detail: str = None) -> ValidationResult:
+    return ValidationResult(ValidationLevel.ERROR, category, message, detail)
+
+
+def _warn(category: str, message: str, detail: str = None) -> ValidationResult:
+    return ValidationResult(ValidationLevel.WARNING, category, message, detail)
+
+
+def _make_iterable(x: Any) -> list:
+    """Return *x* as a list; wraps scalars, passes lists/tuples through."""
+    if isinstance(x, (list, tuple)):
+        return list(x)
+    if x is None:
+        return []
+    return [x]
+
+
+def _settings_as_dict(settings: Any) -> dict:
+    """Normalise a Settings object or plain dict to a plain dict."""
+    if hasattr(settings, "to_dict"):
+        return settings.to_dict()
+    if hasattr(settings, "get_data"):
+        return settings.get_data()
+    if isinstance(settings, dict):
+        return settings
+    raise TypeError(f"settings must be a dict or Settings object, got {type(settings)}")
+
+
+def _extract_planning_periods(settings: dict) -> List[Tuple[int, int]]:
+    """Return ``(first_planning_year, model_year)`` pairs for all planning periods.
+
+    Returns an empty list if the planning-year keys are absent, which the
+    ``_check_required_keys`` validator will already flag as an ERROR.
+    """
+    if "model_periods" in settings and settings["model_periods"] is not None:
+        raw = _make_iterable(settings["model_periods"])
+        if not raw:
+            return []
+        # Handle single period stored as a flat [first, last] rather than [[first, last]]
+        if not isinstance(raw[0], (list, tuple)):
+            raw = [raw]
+        result = []
+        for p in raw:
+            try:
+                result.append((int(p[0]), int(p[1])))
+            except (TypeError, IndexError, ValueError):
+                pass
+        return result
+
+    if "model_year" in settings and "model_first_planning_year" in settings:
+        model_years = _make_iterable(settings["model_year"])
+        first_years = _make_iterable(settings["model_first_planning_year"])
+        return [(int(fy), int(ey)) for fy, ey in zip(first_years, model_years)]
+
+    return []
+
+
+def _tech_matches_any_key(tech_name: str, tag_dict: dict) -> bool:
+    """Return True if any key in *tag_dict* is a case-insensitive substring of *tech_name*.
+
+    This mirrors the logic in ``generators.add_resource_tags()`` which uses
+    ``DataFrame.str.contains(key, case=False)`` for each tag key.
+    """
+    tech_lower = tech_name.lower()
+    for key in tag_dict:
+        if str(key).lower() in tech_lower:
+            return True
+    return False
+
+
+def _tech_has_required_tag(tech_name: str, model_tag_values: dict) -> bool:
+    """Return True if *tech_name* will receive at least one required model tag."""
+    for tag in _REQUIRED_TAGS:
+        tag_dict = model_tag_values.get(tag) or {}
+        if _tech_matches_any_key(tech_name, tag_dict):
+            return True
+    return False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Phase 1 checks (settings-only, no data access)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _check_required_keys(settings: dict) -> List[ValidationResult]:
+    """ERROR if ``model_regions`` or ``target_usd_year`` are absent.
+
+    Also checks that planning year information is present as either
+    ``model_periods`` or the pair ``model_year`` + ``model_first_planning_year``.
+    """
+    results = []
+
+    for key in ("model_regions", "target_usd_year"):
+        if not settings.get(key):
+            results.append(
+                _err(
+                    "required_keys",
+                    f"Required settings key '{key}' is missing or empty",
+                )
+            )
+
+    has_periods = bool(settings.get("model_periods"))
+    has_legacy = bool(settings.get("model_year")) and bool(
+        settings.get("model_first_planning_year")
+    )
+    if not has_periods and not has_legacy:
+        results.append(
+            _err(
+                "required_keys",
+                "Settings must include either 'model_periods' or both "
+                "'model_year' and 'model_first_planning_year'",
+            )
+        )
+
+    return results
+
+
+def _check_year_list_consistency(settings: dict) -> List[ValidationResult]:
+    """Validate planning-year definitions for structural problems.
+
+    For **model_periods**: each entry must be a 2-element list/tuple and the
+    first year must not exceed the last year.
+
+    For the legacy **model_year / model_first_planning_year** pair: both lists
+    must have the same length and each first-year must not exceed its model-year.
+    """
+    results = []
+
+    if settings.get("model_periods"):
+        raw = _make_iterable(settings["model_periods"])
+        # Detect single flat period [first, last] vs list of periods [[f,l], ...]
+        if raw and not isinstance(raw[0], (list, tuple)):
+            raw = [raw]
+
+        bad = [p for p in raw if not isinstance(p, (list, tuple)) or len(p) != 2]
+        if bad:
+            results.append(
+                _err(
+                    "planning_years",
+                    "Each entry in 'model_periods' must be a 2-element list "
+                    "[first_year, end_year]",
+                    detail=f"Invalid entries: {bad}",
+                )
+            )
+
+        for p in raw:
+            if isinstance(p, (list, tuple)) and len(p) == 2:
+                try:
+                    if int(p[0]) > int(p[1]):
+                        results.append(
+                            _err(
+                                "planning_years",
+                                f"model_periods entry has first_year ({p[0]}) > "
+                                f"end_year ({p[1]})",
+                            )
+                        )
+                except (TypeError, ValueError):
+                    pass
+        return results
+
+    if settings.get("model_year") and settings.get("model_first_planning_year"):
+        my_list = _make_iterable(settings["model_year"])
+        fp_list = _make_iterable(settings["model_first_planning_year"])
+        if len(my_list) != len(fp_list):
+            results.append(
+                _err(
+                    "planning_years",
+                    f"'model_year' ({len(my_list)} value(s)) and "
+                    f"'model_first_planning_year' ({len(fp_list)} value(s)) "
+                    "must have the same number of entries",
+                    detail=f"model_year={my_list}, "
+                    f"model_first_planning_year={fp_list}",
+                )
+            )
+        for fy, ey in zip(fp_list, my_list):
+            try:
+                if int(fy) > int(ey):
+                    results.append(
+                        _err(
+                            "planning_years",
+                            f"model_first_planning_year ({fy}) > model_year ({ey})",
+                        )
+                    )
+            except (TypeError, ValueError):
+                pass
+
+    return results
+
+
+def _check_paths_exist(settings: dict) -> List[ValidationResult]:
+    """ERROR if configured file-system paths do not exist."""
+    results = []
+
+    for key in ("data_location", "RESOURCE_GROUPS", "RESOURCE_GROUP_PROFILES"):
+        val = settings.get(key)
+        if val is None:
+            continue
+        if not Path(val).exists():
+            results.append(
+                _err("paths", f"Path specified in '{key}' does not exist: {val}")
+            )
+
+    input_folder = settings.get("input_folder")
+    if input_folder:
+        if not Path(input_folder).exists():
+            results.append(
+                _err("paths", f"'input_folder' path does not exist: {input_folder}")
+            )
+        else:
+            scenario_fn = settings.get("scenario_definitions_fn")
+            if scenario_fn:
+                scenario_path = Path(input_folder) / scenario_fn
+                if not scenario_path.exists():
+                    results.append(
+                        _err(
+                            "paths",
+                            f"'scenario_definitions_fn' file not found: {scenario_path}",
+                        )
+                    )
+
+    return results
+
+
+def _check_region_consistency(settings: dict) -> List[ValidationResult]:
+    """WARNING if any region-keyed setting contains regions not in ``model_regions``.
+
+    Checks the following settings keys whose top-level dict keys must be model
+    region names:
+
+    * ``regional_tag_values``
+    * ``alt_num_clusters``
+    * ``regional_no_grouping``
+    * ``new_gen_not_available``
+    * ``regional_hydro_factor``
+    * ``cost_multiplier_region_map``
+    * ``distributed_gen_method``
+    * ``regional_capacity_reserves`` (nested: constraint → region → value)
+    * ``small_hydro_regions`` (list)
+    """
+    results = []
+
+    model_regions = set(settings.get("model_regions") or [])
+    if not model_regions:
+        return results  # already flagged by _check_required_keys
+
+    simple_keys = [
+        "regional_tag_values",
+        "alt_num_clusters",
+        "regional_no_grouping",
+        "new_gen_not_available",
+        "regional_hydro_factor",
+        "cost_multiplier_region_map",
+        "distributed_gen_method",
+    ]
+    for key in simple_keys:
+        val = settings.get(key)
+        if not val or not isinstance(val, dict):
+            continue
+        unknown = set(val.keys()) - model_regions
+        if unknown:
+            results.append(
+                _warn(
+                    "region_consistency",
+                    f"'{key}' contains region keys not in 'model_regions': "
+                    f"{sorted(unknown)}",
+                    detail=f"model_regions={sorted(model_regions)}",
+                )
+            )
+
+    # regional_capacity_reserves: {constraint: {region: value}}
+    cap_reserves = settings.get("regional_capacity_reserves")
+    if cap_reserves and isinstance(cap_reserves, dict):
+        for constraint, region_map in cap_reserves.items():
+            if not isinstance(region_map, dict):
+                continue
+            unknown = set(region_map.keys()) - model_regions
+            if unknown:
+                results.append(
+                    _warn(
+                        "region_consistency",
+                        f"'regional_capacity_reserves[{constraint}]' contains region "
+                        f"keys not in 'model_regions': {sorted(unknown)}",
+                    )
+                )
+
+    # small_hydro_regions: list
+    small_hydro_regions = settings.get("small_hydro_regions")
+    if small_hydro_regions and isinstance(small_hydro_regions, list):
+        unknown = set(small_hydro_regions) - model_regions
+        if unknown:
+            results.append(
+                _warn(
+                    "region_consistency",
+                    f"'small_hydro_regions' contains regions not in 'model_regions': "
+                    f"{sorted(unknown)}",
+                )
+            )
+
+    return results
+
+
+def _check_model_tag_coverage(settings: dict) -> List[ValidationResult]:
+    """WARNING if a new resource does not match any required model tag.
+
+    Uses the same case-insensitive substring matching as
+    ``generators.add_resource_tags()``.  Resources without a required tag will
+    cause ``GenX.check_resource_tags()`` to raise a ``ValueError`` later.
+
+    Checks ``new_resources`` and ``modified_new_resources``.  Existing
+    resources (``num_clusters``) cannot be checked without generator data.
+    """
+    results = []
+
+    model_tag_values = settings.get("model_tag_values") or {}
+    if not model_tag_values:
+        return results
+
+    untagged: List[str] = []
+
+    # new_resources: [[technology, tech_detail, cost_case, size_mw], ...]
+    for resource in settings.get("new_resources") or []:
+        if not isinstance(resource, (list, tuple)) or len(resource) < 2:
+            continue
+        full_name = f"{resource[0]}_{resource[1]}"
+        if not _tech_has_required_tag(full_name, model_tag_values):
+            # Also try just the technology component alone
+            if not _tech_has_required_tag(str(resource[0]), model_tag_values):
+                untagged.append(full_name)
+
+    # modified_new_resources: {user_name: {new_technology, new_tech_detail, ...}}
+    for name, spec in (settings.get("modified_new_resources") or {}).items():
+        if not isinstance(spec, dict):
+            continue
+        tech = spec.get("new_technology") or spec.get("technology") or name
+        detail = spec.get("new_tech_detail") or spec.get("tech_detail") or ""
+        full_name = f"{tech}_{detail}" if detail else str(tech)
+        if not _tech_has_required_tag(full_name, model_tag_values):
+            if not _tech_has_required_tag(str(tech), model_tag_values):
+                untagged.append(f"{name} (technology={tech})")
+
+    if untagged:
+        results.append(
+            _warn(
+                "model_tag_coverage",
+                f"{len(untagged)} new resource(s) do not match any required model tag "
+                f"(THERM / VRE / MUST_RUN / STOR / FLEX / HYDRO) in 'model_tag_values'",
+                detail=f"Untagged: {untagged}",
+            )
+        )
+
+    return results
+
+
+def _check_fuel_consistency(settings: dict) -> List[ValidationResult]:
+    """Warn about missing or incomplete fuel definitions.
+
+    Checks:
+
+    * Every fuel referenced in ``tech_fuel_map`` must appear in
+      ``fuel_scenarios`` or ``user_fuel_price``; otherwise the generator will
+      receive a ``$0/MMBtu`` price via ``fillna(0)``.
+    * Every CCS fuel in ``ccs_fuel_map`` must exist in ``ccs_capture_rate``;
+      otherwise the CCS capture rate silently defaults to 0 % (no CO₂ removed).
+    * Every CCS fuel's base fuel must be in ``fuel_emission_factors``; otherwise
+      CO₂ content silently defaults to 0.
+    """
+    results = []
+
+    tech_fuel_map = settings.get("tech_fuel_map") or {}
+    fuel_scenarios = set((settings.get("fuel_scenarios") or {}).keys())
+    user_fuel_price = set((settings.get("user_fuel_price") or {}).keys())
+    all_defined_fuels = fuel_scenarios | user_fuel_price
+
+    # Fuels in tech_fuel_map must be defined somewhere
+    missing_fuels = {
+        fuel
+        for fuel in tech_fuel_map.values()
+        if fuel and fuel not in all_defined_fuels
+    }
+    if missing_fuels:
+        results.append(
+            _warn(
+                "fuel_consistency",
+                f"Fuel(s) in 'tech_fuel_map' are not defined in 'fuel_scenarios' or "
+                f"'user_fuel_price': {sorted(missing_fuels)}",
+                detail=(
+                    "Generators using these fuels will receive a $0/MMBtu price "
+                    "via fillna(0)"
+                ),
+            )
+        )
+
+    # CCS-specific checks
+    ccs_fuel_map = settings.get("ccs_fuel_map") or {}
+    ccs_capture_rate = settings.get("ccs_capture_rate") or {}
+    fuel_emission_factors = settings.get("fuel_emission_factors") or {}
+
+    for tech, ccs_fuel_name in ccs_fuel_map.items():
+        # Capture rate must be defined or CCS silently does nothing
+        if ccs_fuel_name not in ccs_capture_rate:
+            results.append(
+                _warn(
+                    "fuel_consistency",
+                    f"CCS fuel '{ccs_fuel_name}' (mapped from tech '{tech}') is not in "
+                    f"'ccs_capture_rate' — capture rate silently defaults to 0 %",
+                    detail=(
+                        "With 0 % capture, CCS carries full CO₂ emissions but still "
+                        "incurs disposal costs"
+                    ),
+                )
+            )
+
+        # Base fuel must have an emission factor
+        if "_ccs" in ccs_fuel_name.lower():
+            idx = ccs_fuel_name.lower().index("_ccs")
+            base_fuel = ccs_fuel_name[:idx]
+        else:
+            parts = ccs_fuel_name.split("_")
+            base_fuel = "_".join(parts[:-1]) if len(parts) > 1 else ccs_fuel_name
+
+        if base_fuel and base_fuel not in fuel_emission_factors:
+            results.append(
+                _warn(
+                    "fuel_consistency",
+                    f"CCS fuel '{ccs_fuel_name}' base fuel '{base_fuel}' is not in "
+                    f"'fuel_emission_factors' — CO₂ content will default to 0",
+                    detail=f"tech: {tech}, ccs_fuel_map entry: {ccs_fuel_name}",
+                )
+            )
+
+    return results
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Phase 1 entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
+_PHASE1_CHECKS = [
+    _check_required_keys,
+    _check_year_list_consistency,
+    _check_paths_exist,
+    _check_region_consistency,
+    _check_model_tag_coverage,
+    _check_fuel_consistency,
+]
+
+
+def validate_settings(settings: Any) -> List[ValidationResult]:
+    """Phase 1: validate settings internal consistency without accessing any data.
+
+    Parameters
+    ----------
+    settings : dict or Settings
+        Loaded PowerGenome settings (before or after scenario resolution).
+
+    Returns
+    -------
+    list[ValidationResult]
+        All detected issues.  An empty list means no problems were found.
+    """
+    d = _settings_as_dict(settings)
+    results: List[ValidationResult] = []
+    for check_fn in _PHASE1_CHECKS:
+        try:
+            results.extend(check_fn(d))
+        except Exception:
+            logger.debug(
+                "Validation check %s raised an unexpected exception",
+                check_fn.__name__,
+                exc_info=True,
+            )
+    return results
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Phase 2 checks (settings + DataManager)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _check_transmission_regions(settings: dict, dm: Any) -> List[ValidationResult]:
+    """WARNING if transmission cost table contains regions absent from ``model_regions``.
+
+    Such rows are silently dropped by ``transmission.load_tx_costs()`` via
+    ``.dropna(subset=['zone_1', 'zone_2'])`` after the unmapped regions produce
+    ``NaN`` in the zone-number columns.
+    """
+    results = []
+
+    if "transmission_cost" not in (dm.available_tables or set()):
+        return results
+
+    try:
+        tx_df = dm.get_data(
+            "transmission_cost", columns=["start_region", "dest_region"]
+        )
+    except Exception as exc:
+        results.append(
+            _warn(
+                "transmission_regions",
+                f"Could not load transmission_cost table for validation: {exc}",
+            )
+        )
+        return results
+
+    model_regions = set(settings.get("model_regions") or [])
+    # Base IPM regions (from region_aggregations values) are also valid here
+    agg_regions = settings.get("region_aggregations") or {}
+    base_regions: set = set()
+    for base_list in agg_regions.values():
+        if isinstance(base_list, (list, tuple)):
+            base_regions.update(base_list)
+    valid_regions = model_regions | base_regions
+
+    all_in_table = set(tx_df["start_region"].dropna()) | set(
+        tx_df["dest_region"].dropna()
+    )
+    unknown = all_in_table - valid_regions
+    if unknown:
+        results.append(
+            _warn(
+                "transmission_regions",
+                f"'transmission_cost_table' contains {len(unknown)} region(s) not in "
+                f"'model_regions' or their constituent IPM regions — these rows will "
+                f"be silently dropped during transmission processing",
+                detail=f"Unknown regions: {sorted(unknown)}",
+            )
+        )
+
+    return results
+
+
+def _check_fuel_price_coverage(settings: dict, dm: Any) -> List[ValidationResult]:
+    """WARNING if any fuel/scenario/region/year combination is missing from the fuel-price table.
+
+    Missing combinations produce ``$0/MMBtu`` in the GenX ``Fuels_data.csv``
+    output via ``fillna(0)`` in ``fuels.fuel_cost_table()``.
+
+    Checks every fuel defined in ``fuel_scenarios`` for each model year (the
+    end year of each planning period) and each base region that makes up the
+    model regions.
+    """
+    results = []
+
+    if "fuel_price" not in (dm.available_tables or set()):
+        return results
+
+    planning_periods = _extract_planning_periods(settings)
+    if not planning_periods:
+        return results
+
+    model_years = [p[1] for p in planning_periods]
+    fuel_scenarios: Dict[str, str] = settings.get("fuel_scenarios") or {}
+    model_regions: List[str] = list(settings.get("model_regions") or [])
+    region_aggregations: Dict[str, list] = settings.get("region_aggregations") or {}
+
+    if not fuel_scenarios or not model_regions:
+        return results
+
+    try:
+        fuel_df = dm.get_data(
+            "fuel_price", columns=["year", "fuel", "region", "scenario"]
+        )
+    except Exception as exc:
+        results.append(
+            _warn(
+                "fuel_price_coverage",
+                f"Could not load fuel_price table for validation: {exc}",
+            )
+        )
+        return results
+
+    if fuel_df.empty or "year" not in fuel_df.columns:
+        return results
+
+    # Coerce year column to int for comparison
+    try:
+        fuel_df["year"] = fuel_df["year"].astype(int)
+    except Exception:
+        pass
+
+    has_region_col = "region" in fuel_df.columns
+    has_scenario_col = "scenario" in fuel_df.columns
+
+    missing: List[str] = []
+    for fuel, scenario in fuel_scenarios.items():
+        for model_year in model_years:
+            # Resolve which base regions we need prices for
+            base_regions_needed: List[str] = []
+            for region in model_regions:
+                if region in region_aggregations:
+                    base_regions_needed.extend(region_aggregations[region])
+                else:
+                    base_regions_needed.append(region)
+
+            for region in base_regions_needed:
+                mask = fuel_df["year"] == model_year
+                if has_region_col:
+                    mask &= fuel_df["region"] == region
+                if has_scenario_col and scenario:
+                    mask &= fuel_df["scenario"] == scenario
+                # Match on fuel name
+                if "fuel" in fuel_df.columns:
+                    mask &= fuel_df["fuel"] == fuel
+
+                if not mask.any():
+                    missing.append(
+                        f"fuel={fuel}, scenario={scenario}, "
+                        f"region={region}, year={model_year}"
+                    )
+
+    if missing:
+        shown = missing[:10]
+        truncated = f"  … and {len(missing) - 10} more" if len(missing) > 10 else ""
+        results.append(
+            _warn(
+                "fuel_price_coverage",
+                f"{len(missing)} fuel/scenario/region/year combination(s) are missing "
+                f"from the fuel_price table — missing prices will become $0/MMBtu via "
+                f"fillna(0)",
+                detail="\n    ".join(shown) + truncated,
+            )
+        )
+
+    return results
+
+
+def _check_new_resource_cost_years(settings: dict, dm: Any) -> List[ValidationResult]:
+    """WARNING if a new-resource/planning-period combination has no cost data.
+
+    ``new_build.single_generator_row()`` averages costs over
+    ``range(first_planning_year, model_year + 1)`` in the ``basis_year``
+    column.  If no rows match, ``.mean()`` returns ``NaN`` which then becomes
+    ``$0`` via ``fillna(0)`` — silently zeroing capex and fixed/variable O&M.
+    """
+    results = []
+
+    if "resource_cost" not in (dm.available_tables or set()):
+        return results
+
+    new_resources = settings.get("new_resources") or []
+    if not new_resources:
+        return results
+
+    planning_periods = _extract_planning_periods(settings)
+    if not planning_periods:
+        return results
+
+    try:
+        cost_df = dm.get_data(
+            "resource_cost",
+            columns=["technology", "tech_detail", "cost_case", "basis_year"],
+        )
+    except Exception as exc:
+        results.append(
+            _warn(
+                "new_resource_cost_years",
+                f"Could not load resource_cost table for validation: {exc}",
+            )
+        )
+        return results
+
+    if cost_df.empty:
+        return results
+
+    # Coerce basis_year to int for set operations
+    try:
+        cost_df["basis_year"] = cost_df["basis_year"].astype(int)
+    except Exception:
+        pass
+
+    no_overlap: List[str] = []
+    for resource in new_resources:
+        if not isinstance(resource, (list, tuple)) or len(resource) < 3:
+            continue
+        technology, tech_detail, cost_case = (
+            str(resource[0]),
+            str(resource[1]),
+            str(resource[2]),
+        )
+
+        available_years: set = set(
+            cost_df.loc[
+                (cost_df["technology"] == technology)
+                & (cost_df["tech_detail"] == tech_detail)
+                & (cost_df["cost_case"] == cost_case),
+                "basis_year",
+            ].dropna()
+        )
+
+        if not available_years:
+            no_overlap.append(
+                f"{technology}/{tech_detail}/{cost_case}: "
+                f"no matching rows found in resource_cost table"
+            )
+            continue
+
+        for first_year, end_year in planning_periods:
+            period_range = set(range(first_year, end_year + 1))
+            if period_range.isdisjoint(available_years):
+                available_sample = sorted(available_years)[:5]
+                ellipsis = "…" if len(available_years) > 5 else ""
+                no_overlap.append(
+                    f"{technology}/{tech_detail}/{cost_case}: "
+                    f"no basis_year in {first_year}–{end_year} "
+                    f"(available: {available_sample}{ellipsis})"
+                )
+
+    if no_overlap:
+        results.append(
+            _warn(
+                "new_resource_cost_years",
+                f"{len(no_overlap)} new resource/period combination(s) have no "
+                f"matching basis_year in the resource_cost table — costs will be "
+                f"$0 via fillna(0)",
+                detail="\n    ".join(no_overlap),
+            )
+        )
+
+    return results
+
+
+def _check_data_tables_loaded(settings: dict, dm: Any) -> List[ValidationResult]:
+    """ERROR if a settings-configured table was not loaded into DataManager.
+
+    With lazy loading, ``DataManager`` creates a *view* pointing at the source
+    file during ``initialize()``.  If the source file does not exist the view
+    is still registered in ``available_tables`` but will fail at query time.
+    This check catches the less common case where ``available_tables`` is
+    actually missing a table that was requested.
+    """
+    results = []
+
+    try:
+        from powergenome.database import DataManager as _DM
+
+        mapping = _DM.STANDARD_TABLE_MAPPING
+    except Exception:
+        return results
+
+    available = dm.available_tables or set()
+    for setting_key, standard_name in mapping.items():
+        if settings.get(setting_key) and standard_name not in available:
+            results.append(
+                _err(
+                    "data_tables",
+                    f"Settings key '{setting_key}' is configured but the table "
+                    f"'{standard_name}' was not loaded by DataManager — "
+                    f"check that the file exists in 'data_location'",
+                )
+            )
+
+    return results
+
+
+def _check_aggregation_base_regions(settings: dict, dm: Any) -> List[ValidationResult]:
+    """WARNING if a base region referenced in ``model_regions`` or ``region_aggregations`` is not found in any data table.
+
+    Two sources of base regions are checked:
+
+    1. **Aggregation values** — every region listed as a value in
+       ``region_aggregations`` (e.g. ``AZ: [p1, q2]`` → checks ``p1`` and
+       ``q2``).
+    2. **Pass-through model regions** — entries in ``model_regions`` that have
+       no entry in ``region_aggregations`` are treated by PowerGenome as a
+       direct 1:1 base region (e.g. ``model_regions: [p1_2, q2]`` where
+       ``q2`` is not a key in ``region_aggregations``).
+
+    Both sets are validated against the region names present in the
+    ``plant_region``, ``demand``, ``fuel_price``, and ``transmission_cost``
+    tables (whichever are loaded).  A typo in either location will be caught
+    because the misspelled name will not appear in any data table.
+    """
+    results = []
+
+    model_regions: List[str] = list(settings.get("model_regions") or [])
+    region_aggregations = settings.get("region_aggregations") or {}
+
+    # All base regions listed across the aggregation values
+    aggregation_base_regions: set = set()
+    for base_list in region_aggregations.values():
+        if isinstance(base_list, (list, tuple)):
+            aggregation_base_regions.update(str(r) for r in base_list)
+
+    # Pass-through model regions: in model_regions but NOT a key in region_aggregations
+    passthrough_regions: set = {
+        str(r) for r in model_regions if str(r) not in region_aggregations
+    }
+
+    all_base_regions = aggregation_base_regions | passthrough_regions
+    if not all_base_regions:
+        return results
+
+    available = dm.available_tables or set()
+    known_regions: set = set()
+
+    # ── plant_region ──────────────────────────────────────────────────────────
+    if "plant_region" in available:
+        try:
+            pr_df = dm.get_data("plant_region", columns=["region"])
+            if "region" in pr_df.columns:
+                known_regions.update(pr_df["region"].dropna().astype(str))
+        except Exception:
+            pass
+
+    # ── demand ────────────────────────────────────────────────────────────────
+    if "demand" in available:
+        try:
+            dem_df = dm.get_data("demand", columns=["region"])
+            if "region" in dem_df.columns:
+                known_regions.update(dem_df["region"].dropna().astype(str))
+        except Exception:
+            pass
+
+    # ── fuel_price ────────────────────────────────────────────────────────────
+    if "fuel_price" in available:
+        try:
+            fp_df = dm.get_data("fuel_price", columns=["region"])
+            if "region" in fp_df.columns:
+                known_regions.update(fp_df["region"].dropna().astype(str))
+        except Exception:
+            pass
+
+    # ── transmission_cost ─────────────────────────────────────────────────────
+    if "transmission_cost" in available:
+        try:
+            tx_df = dm.get_data(
+                "transmission_cost", columns=["start_region", "dest_region"]
+            )
+            for col in ("start_region", "dest_region"):
+                if col in tx_df.columns:
+                    known_regions.update(tx_df[col].dropna().astype(str))
+        except Exception:
+            pass
+
+    # If no tables were available or all failed, skip silently
+    if not known_regions:
+        return results
+
+    unknown = all_base_regions - known_regions
+    if unknown:
+        # Build per-model-region detail lines for actionable error messages
+        detail_lines: List[str] = []
+        # Regions from region_aggregations values
+        for model_region, base_list in region_aggregations.items():
+            if not isinstance(base_list, (list, tuple)):
+                continue
+            bad = sorted(str(r) for r in base_list if str(r) in unknown)
+            if bad:
+                detail_lines.append(f"{model_region} (aggregation): {bad}")
+        # Pass-through model regions
+        bad_passthrough = sorted(r for r in passthrough_regions if r in unknown)
+        for r in bad_passthrough:
+            detail_lines.append(f"{r} (model_regions pass-through): not found in data")
+        results.append(
+            _warn(
+                "aggregation_base_regions",
+                f"{len(unknown)} base region(s) referenced in 'model_regions' or "
+                f"'region_aggregations' do not appear in any data table "
+                f"(plant_region, demand, fuel_price, transmission_cost) — check for typos",
+                detail="\n    ".join(detail_lines),
+            )
+        )
+
+    return results
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Phase 2 entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
+_PHASE2_CHECKS = [
+    _check_data_tables_loaded,
+    _check_aggregation_base_regions,
+    _check_transmission_regions,
+    _check_fuel_price_coverage,
+    _check_new_resource_cost_years,
+]
+
+
+def validate_settings_with_data(
+    settings: Any, data_manager: Any
+) -> List[ValidationResult]:
+    """Phase 2: validate settings against loaded data tables.
+
+    Requires ``DataManager`` to already be initialised (call
+    ``initialize_data_manager()`` first).
+
+    Parameters
+    ----------
+    settings : dict or Settings
+        Loaded PowerGenome settings.
+    data_manager : DataManager
+        Initialised DataManager singleton.
+
+    Returns
+    -------
+    list[ValidationResult]
+        All detected issues.  An empty list means no problems were found.
+    """
+    d = _settings_as_dict(settings)
+    results: List[ValidationResult] = []
+    for check_fn in _PHASE2_CHECKS:
+        try:
+            results.extend(check_fn(d, data_manager))
+        except Exception:
+            logger.debug(
+                "Validation check %s raised an unexpected exception",
+                check_fn.__name__,
+                exc_info=True,
+            )
+    return results
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Reporting
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def report_validation_results(
+    results: List[ValidationResult],
+    raise_on_error: bool = True,
+) -> None:
+    """Log all validation results and optionally raise on ERRORs.
+
+    Parameters
+    ----------
+    results : list[ValidationResult]
+        Results from :func:`validate_settings` or
+        :func:`validate_settings_with_data`.
+    raise_on_error : bool
+        If ``True`` (default), raise ``ValueError`` if any ERROR-level results
+        are present.
+
+    Raises
+    ------
+    ValueError
+        If any ERROR-level results are present and *raise_on_error* is ``True``.
+    """
+    warnings_ = [r for r in results if r.level == ValidationLevel.WARNING]
+    errors_ = [r for r in results if r.level == ValidationLevel.ERROR]
+
+    for result in warnings_:
+        logger.warning(str(result))
+    for result in errors_:
+        logger.error(str(result))
+
+    if raise_on_error and errors_:
+        error_messages = "\n".join(str(r) for r in errors_)
+        raise ValueError(
+            f"PowerGenome settings validation found {len(errors_)} error(s):\n"
+            f"{error_messages}"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Standalone CLI  (validate_powergenome)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_validate_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="validate_powergenome",
+        description=(
+            "Validate PowerGenome settings for common configuration issues.\n\n"
+            "Phase 1 (always run): checks settings internal consistency without "
+            "reading any data files.\n"
+            "Phase 2 (default): checks settings against loaded data tables via "
+            "DataManager."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-sf",
+        "--settings_file",
+        dest="settings_file",
+        type=str,
+        required=True,
+        help="Path to settings YAML file or directory.",
+    )
+    parser.add_argument(
+        "--skip-data-checks",
+        dest="skip_data_checks",
+        action="store_true",
+        default=False,
+        help="Only run Phase 1 (settings-only) checks — skip DataManager-based checks.",
+    )
+    parser.add_argument(
+        "--no-fail",
+        dest="no_fail",
+        action="store_true",
+        default=False,
+        help=(
+            "Exit with code 0 even if errors are found.  "
+            "Errors are still logged at ERROR level."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def validate_powergenome() -> None:
+    """Entry point for the ``validate_powergenome`` CLI command."""
+    _logging = logging
+    _log = _logging.getLogger("powergenome")
+    _log.setLevel(_logging.DEBUG)
+    handler = _logging.StreamHandler()
+    handler.setFormatter(_logging.Formatter("%(levelname)-8s %(name)s: %(message)s"))
+    handler.setLevel(_logging.INFO)
+    _log.addHandler(handler)
+
+    args = _parse_validate_args()
+    has_errors = False
+
+    # ── Phase 1 ────────────────────────────────────────────────────────────────
+    from powergenome.settings import Settings
+
+    logger.info("Loading settings from: %s", args.settings_file)
+    settings = Settings(config_path=args.settings_file)
+
+    logger.info("Running Phase 1 validation (settings-only checks) …")
+    p1_results = validate_settings(settings)
+    if p1_results:
+        report_validation_results(p1_results, raise_on_error=False)
+        has_errors = any(r.level == ValidationLevel.ERROR for r in p1_results)
+        p1_warns = sum(r.level == ValidationLevel.WARNING for r in p1_results)
+        p1_errs = sum(r.level == ValidationLevel.ERROR for r in p1_results)
+        logger.info("Phase 1 complete: %d error(s), %d warning(s)", p1_errs, p1_warns)
+    else:
+        logger.info("Phase 1 complete: no issues found.")
+
+    # ── Phase 2 ────────────────────────────────────────────────────────────────
+    if not args.skip_data_checks:
+        data_location = settings.get("data_location")
+        if not data_location:
+            logger.warning(
+                "Skipping Phase 2 data checks: 'data_location' is not configured."
+            )
+        else:
+            from powergenome.database import _data_manager, initialize_data_manager
+
+            logger.info("Running Phase 2 validation (data checks) …")
+            try:
+                initialize_data_manager(settings, data_location)
+                p2_results = validate_settings_with_data(settings, _data_manager)
+                if p2_results:
+                    report_validation_results(p2_results, raise_on_error=False)
+                    has_errors = has_errors or any(
+                        r.level == ValidationLevel.ERROR for r in p2_results
+                    )
+                    p2_warns = sum(
+                        r.level == ValidationLevel.WARNING for r in p2_results
+                    )
+                    p2_errs = sum(r.level == ValidationLevel.ERROR for r in p2_results)
+                    logger.info(
+                        "Phase 2 complete: %d error(s), %d warning(s)",
+                        p2_errs,
+                        p2_warns,
+                    )
+                else:
+                    logger.info("Phase 2 complete: no issues found.")
+            except Exception as exc:
+                logger.error("Phase 2 validation failed unexpectedly: %s", exc)
+                has_errors = True
+
+    if has_errors and not args.no_fail:
+        sys.exit(1)

--- a/powergenome/validate.py
+++ b/powergenome/validate.py
@@ -556,11 +556,19 @@ def validate_settings(settings: Any) -> List[ValidationResult]:
     for check_fn in _PHASE1_CHECKS:
         try:
             results.extend(check_fn(d))
-        except Exception:
+        except Exception as exc:
             logger.debug(
                 "Validation check %s raised an unexpected exception",
                 check_fn.__name__,
                 exc_info=True,
+            )
+            results.append(
+                _err(
+                    "internal_error",
+                    f"Validation check '{check_fn.__name__}' raised an unexpected "
+                    f"exception — this is a bug; some checks may have been skipped",
+                    detail=f"{type(exc).__name__}: {exc}",
+                )
             )
     return results
 
@@ -995,11 +1003,19 @@ def validate_settings_with_data(
     for check_fn in _PHASE2_CHECKS:
         try:
             results.extend(check_fn(d, data_manager))
-        except Exception:
+        except Exception as exc:
             logger.debug(
                 "Validation check %s raised an unexpected exception",
                 check_fn.__name__,
                 exc_info=True,
+            )
+            results.append(
+                _err(
+                    "internal_error",
+                    f"Validation check '{check_fn.__name__}' raised an unexpected "
+                    f"exception — this is a bug; some checks may have been skipped",
+                    detail=f"{type(exc).__name__}: {exc}",
+                )
             )
     return results
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ docs = ["mkdocs>=1.5.0", "mkdocs-material>=9.4.0", "mike>=2.0.0"]
 
 [project.scripts]
 run_powergenome = "powergenome.run_powergenome:main"
+validate_powergenome = "powergenome.validate:validate_powergenome"
 
 [project.urls]
 "Source" = "https://github.com/PowerGenome/PowerGenome"

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -30,6 +30,27 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 
+@pytest.fixture(autouse=True)
+def _patch_validation(monkeypatch):
+    """Patch validation functions so CLI tests are not affected by mock Settings objects.
+
+    cli_test.py tests the pipeline control flow using MagicMock settings objects.
+    The validation module is tested separately in validate_test.py.
+    """
+    monkeypatch.setattr(
+        "powergenome.run_powergenome.validate_settings",
+        lambda s: [],
+    )
+    monkeypatch.setattr(
+        "powergenome.run_powergenome.validate_settings_with_data",
+        lambda s, dm: [],
+    )
+    monkeypatch.setattr(
+        "powergenome.run_powergenome.report_validation_results",
+        lambda results, raise_on_error=True: None,
+    )
+
+
 @pytest.fixture
 def test_settings_path():
     """Get path to test system settings directory."""

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -577,14 +577,20 @@ class TestValidateSettings:
             for r in results
         )
 
-    def test_check_exceptions_are_swallowed(self, monkeypatch):
+    def test_check_exceptions_become_error_results(self, monkeypatch):
         import powergenome.validate as validate_mod
 
         def bad_check(_):
             raise RuntimeError("boom")
 
         monkeypatch.setattr(validate_mod, "_PHASE1_CHECKS", [bad_check])
-        assert validate_settings(_minimal_valid_settings()) == []
+        results = validate_settings(_minimal_valid_settings())
+        assert len(results) == 1
+        assert results[0].level == ValidationLevel.ERROR
+        assert results[0].category == "internal_error"
+        assert "bad_check" in results[0].message
+        assert "RuntimeError" in results[0].detail
+        assert "boom" in results[0].detail
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1307,7 +1313,7 @@ class TestCheckAggregationBaseRegions:
         assert _check_aggregation_base_regions(s, FakeDM()) == []
 
 
-def test_validate_settings_with_data_swallow_check_exception(monkeypatch):
+def test_validate_settings_with_data_checker_exception_becomes_error(monkeypatch):
     import powergenome.validate as validate_mod
 
     def bad_check(_settings, _dm):
@@ -1317,7 +1323,13 @@ def test_validate_settings_with_data_swallow_check_exception(monkeypatch):
         available_tables = set()
 
     monkeypatch.setattr(validate_mod, "_PHASE2_CHECKS", [bad_check])
-    assert validate_settings_with_data(_minimal_valid_settings(), FakeDM()) == []
+    results = validate_settings_with_data(_minimal_valid_settings(), FakeDM())
+    assert len(results) == 1
+    assert results[0].level == ValidationLevel.ERROR
+    assert results[0].category == "internal_error"
+    assert "bad_check" in results[0].message
+    assert "RuntimeError" in results[0].detail
+    assert "boom" in results[0].detail
 
 
 class TestValidateCli:

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -27,9 +27,13 @@ from powergenome.validate import (
     _check_transmission_regions,
     _check_year_list_consistency,
     _extract_planning_periods,
+    _make_iterable,
+    _parse_validate_args,
+    _settings_as_dict,
     _tech_has_required_tag,
     _tech_matches_any_key,
     report_validation_results,
+    validate_powergenome,
     validate_settings,
     validate_settings_with_data,
 )
@@ -95,6 +99,61 @@ def test_extract_planning_periods_legacy():
 
 def test_extract_planning_periods_empty():
     assert _extract_planning_periods({}) == []
+
+
+def test_extract_planning_periods_empty_model_periods_list():
+    assert _extract_planning_periods({"model_periods": []}) == []
+
+
+def test_extract_planning_periods_skips_invalid_period_entries():
+    s = {"model_periods": [["bad", 2030], [2025, 2030], [2025]]}
+    assert _extract_planning_periods(s) == [(2025, 2030)]
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ([1, 2], [1, 2]),
+        ((1, 2), [1, 2]),
+        (None, []),
+        ("x", ["x"]),
+    ],
+)
+def test_make_iterable_variants(value, expected):
+    assert _make_iterable(value) == expected
+
+
+def test_settings_as_dict_from_dict():
+    d = {"a": 1}
+    assert _settings_as_dict(d) is d
+
+
+def test_settings_as_dict_from_to_dict_object():
+    class HasToDict:
+        def to_dict(self):
+            return {"k": "v"}
+
+    assert _settings_as_dict(HasToDict()) == {"k": "v"}
+
+
+def test_settings_as_dict_from_get_data_object():
+    class HasGetData:
+        def get_data(self):
+            return {"x": 2}
+
+    assert _settings_as_dict(HasGetData()) == {"x": 2}
+
+
+def test_settings_as_dict_rejects_invalid_type():
+    with pytest.raises(TypeError, match="settings must be a dict"):
+        _settings_as_dict(123)
+
+
+def test_validation_result_str_with_and_without_detail():
+    no_detail = ValidationResult(ValidationLevel.WARNING, "cat", "msg")
+    with_detail = ValidationResult(ValidationLevel.ERROR, "cat", "msg", detail="more")
+    assert "Detail:" not in str(no_detail)
+    assert "Detail: more" in str(with_detail)
 
 
 def test_tech_matches_any_key_positive():
@@ -224,6 +283,14 @@ class TestCheckYearListConsistency:
         s = {"model_periods": [2025, 2030]}  # flat single period
         assert _check_year_list_consistency(s) == []
 
+    def test_model_periods_non_numeric_values_are_ignored(self):
+        s = {"model_periods": [["bad", 2030]]}
+        assert _check_year_list_consistency(s) == []
+
+    def test_legacy_non_numeric_values_are_ignored(self):
+        s = {"model_year": ["bad"], "model_first_planning_year": [2025]}
+        assert _check_year_list_consistency(s) == []
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Phase 1 — _check_paths_exist
@@ -314,6 +381,13 @@ class TestCheckRegionConsistency:
             "regional_capacity_reserves" in r.message for r in _warnings(results)
         )
 
+    def test_regional_capacity_reserves_non_dict_is_ignored(self):
+        s = {
+            "model_regions": ["r1"],
+            "regional_capacity_reserves": {"CapRes_1": ["r1", 0.15]},
+        }
+        assert _warnings(_check_region_consistency(s)) == []
+
     def test_unknown_small_hydro_region(self):
         s = {
             "model_regions": ["r1", "r2"],
@@ -386,6 +460,13 @@ class TestCheckModelTagCoverage:
         )
         assert _warnings(_check_model_tag_coverage(s)) == []
 
+    def test_malformed_new_resources_entries_are_ignored(self):
+        s = _minimal_valid_settings(
+            new_resources=["bad-entry", ["NaturalGas"]],
+            modified_new_resources={"bad": "not-a-dict"},
+        )
+        assert _check_model_tag_coverage(s) == []
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Phase 1 — _check_fuel_consistency
@@ -438,6 +519,15 @@ class TestCheckFuelConsistency:
         results = _check_fuel_consistency(s)
         assert any("fuel_emission_factors" in r.message for r in _warnings(results))
 
+    def test_ccs_base_fuel_split_without_ccs_suffix(self):
+        s = _minimal_valid_settings(
+            ccs_fuel_map={"GasCCS": "naturalgas_capture90"},
+            ccs_capture_rate={"naturalgas_capture90": 0.9},
+            fuel_emission_factors={},
+        )
+        results = _check_fuel_consistency(s)
+        assert any("naturalgas" in r.message for r in _warnings(results))
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Phase 1 — validate_settings (integration)
@@ -486,6 +576,15 @@ class TestValidateSettings:
             r.level == ValidationLevel.ERROR and "planning_years" == r.category
             for r in results
         )
+
+    def test_check_exceptions_are_swallowed(self, monkeypatch):
+        import powergenome.validate as validate_mod
+
+        def bad_check(_):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(validate_mod, "_PHASE1_CHECKS", [bad_check])
+        assert validate_settings(_minimal_valid_settings()) == []
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -687,6 +786,116 @@ class TestPhase2WithTestData:
         # coal/reference/RegionB/2030 also missing
         assert "naturalgas" in (warns[0].detail or "")
 
+    def test_fuel_price_coverage_returns_when_no_planning_periods(self):
+        class FakeDM:
+            available_tables = {"fuel_price"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                return pd.DataFrame(
+                    {
+                        "year": [2030],
+                        "fuel": ["coal"],
+                        "region": ["RegionA"],
+                        "scenario": ["reference"],
+                    }
+                )
+
+        s = _minimal_valid_settings(model_year=None, model_first_planning_year=None)
+        assert _check_fuel_price_coverage(s, FakeDM()) == []
+
+    def test_fuel_price_coverage_returns_when_fuels_or_regions_missing(self):
+        class FakeDM:
+            available_tables = {"fuel_price"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                return pd.DataFrame({"year": [2030], "fuel": ["coal"]})
+
+        s = _minimal_valid_settings(fuel_scenarios={}, model_regions=[])
+        assert _check_fuel_price_coverage(s, FakeDM()) == []
+
+    def test_fuel_price_coverage_warns_when_table_read_fails(self):
+        class FakeDM:
+            available_tables = {"fuel_price"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                raise RuntimeError("cannot read fuel table")
+
+        s = _minimal_valid_settings()
+        results = _check_fuel_price_coverage(s, FakeDM())
+        assert any(
+            "Could not load fuel_price table" in r.message for r in _warnings(results)
+        )
+
+    def test_fuel_price_coverage_returns_for_empty_or_no_year(self):
+        class FakeDM:
+            available_tables = {"fuel_price"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                return pd.DataFrame()
+
+        s = _minimal_valid_settings()
+        assert _check_fuel_price_coverage(s, FakeDM()) == []
+
+    def test_fuel_price_coverage_handles_non_numeric_year(self):
+        class FakeDM:
+            available_tables = {"fuel_price"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                return pd.DataFrame(
+                    {
+                        "year": ["bad"],
+                        "fuel": ["coal"],
+                        "region": ["RegionA"],
+                        "scenario": ["reference"],
+                    }
+                )
+
+        s = _minimal_valid_settings(fuel_scenarios={"coal": "reference"})
+        results = _check_fuel_price_coverage(s, FakeDM())
+        assert _warnings(results)
+
+    def test_fuel_price_coverage_truncates_long_missing_detail(self):
+        class FakeDM:
+            available_tables = {"fuel_price"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                # Keep table non-empty so the check reaches the missing-combo logic.
+                return pd.DataFrame(
+                    {
+                        "year": [1990],
+                        "fuel": ["coal"],
+                        "region": ["Nowhere"],
+                        "scenario": ["reference"],
+                    }
+                )
+
+        s = _minimal_valid_settings(
+            model_year=[2030, 2040],
+            model_first_planning_year=[2025, 2031],
+            model_regions=["RegionA", "RegionB", "RegionC"],
+            fuel_scenarios={
+                "coal": "reference",
+                "naturalgas": "reference",
+            },
+        )
+        results = _check_fuel_price_coverage(s, FakeDM())
+        warn = _warnings(results)[0]
+        assert "and" in (warn.detail or "")
+
+    def test_transmission_regions_warns_when_table_read_fails(self):
+        class FakeDM:
+            available_tables = {"transmission_cost"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                raise RuntimeError("cannot read tx")
+
+        s = _minimal_valid_settings()
+        results = _check_transmission_regions(s, FakeDM())
+        assert any(
+            "Could not load transmission_cost table" in r.message
+            for r in _warnings(results)
+        )
+
     def test_data_tables_loaded_error_on_missing(self):
         """If a configured table is absent from DataManager, flag as ERROR."""
 
@@ -707,6 +916,18 @@ class TestPhase2WithTestData:
         results = _check_data_tables_loaded(s, FakeDM())
         assert _errors(results) == []
 
+    def test_data_tables_loaded_graceful_when_mapping_unavailable(self, monkeypatch):
+        import powergenome.database as db
+
+        monkeypatch.delattr(db, "DataManager", raising=False)
+
+        class FakeDM:
+            available_tables = set()
+
+        assert (
+            _check_data_tables_loaded({"resource_cost_table": "x.csv"}, FakeDM()) == []
+        )
+
     def test_validate_settings_with_data_integration(
         self, test_settings, initialized_dm
     ):
@@ -716,6 +937,138 @@ class TestPhase2WithTestData:
         report_validation_results(results, raise_on_error=False)
         # The test system should have no ERROR-level issues in Phase 2
         assert _errors(results) == [], f"Unexpected data errors: {_errors(results)}"
+
+    def test_new_resource_cost_years_returns_when_no_new_resources(self):
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame()
+
+        s = _minimal_valid_settings(new_resources=[])
+        assert _check_new_resource_cost_years(s, FakeDM()) == []
+
+    def test_new_resource_cost_years_returns_when_no_planning_periods(self):
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame()
+
+        s = _minimal_valid_settings(
+            new_resources=[["NaturalGas", "CCGT", "Moderate", 500]],
+            model_year=None,
+            model_first_planning_year=None,
+        )
+        assert _check_new_resource_cost_years(s, FakeDM()) == []
+
+    def test_new_resource_cost_years_warns_when_table_read_fails(self):
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+            def get_data(self, *a, **kw):
+                raise RuntimeError("cannot read resource cost")
+
+        s = _minimal_valid_settings(
+            new_resources=[["NaturalGas", "CCGT", "Moderate", 500]]
+        )
+        results = _check_new_resource_cost_years(s, FakeDM())
+        assert any(
+            "Could not load resource_cost table" in r.message
+            for r in _warnings(results)
+        )
+
+    def test_new_resource_cost_years_returns_when_empty_table(self):
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame(
+                    columns=["technology", "tech_detail", "cost_case", "basis_year"]
+                )
+
+        s = _minimal_valid_settings(
+            new_resources=[["NaturalGas", "CCGT", "Moderate", 500]]
+        )
+        assert _check_new_resource_cost_years(s, FakeDM()) == []
+
+    def test_new_resource_cost_years_handles_bad_basis_year_dtype(self):
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame(
+                    {
+                        "technology": ["NaturalGas"],
+                        "tech_detail": ["CCGT"],
+                        "cost_case": ["Moderate"],
+                        "basis_year": ["bad"],
+                    }
+                )
+
+        s = _minimal_valid_settings(
+            new_resources=[["NaturalGas", "CCGT", "Moderate", 500]]
+        )
+        assert _warnings(_check_new_resource_cost_years(s, FakeDM()))
+
+    def test_new_resource_cost_years_skips_malformed_resource_entries(self):
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame(
+                    {
+                        "technology": ["NaturalGas"],
+                        "tech_detail": ["CCGT"],
+                        "cost_case": ["Moderate"],
+                        "basis_year": [2028],
+                    }
+                )
+
+        s = _minimal_valid_settings(new_resources=[["NaturalGas", "CCGT"], "bad"])
+        assert _check_new_resource_cost_years(s, FakeDM()) == []
+
+    def test_new_resource_cost_years_reports_no_matching_rows(self):
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame(
+                    {
+                        "technology": ["Wind"],
+                        "tech_detail": ["Class3"],
+                        "cost_case": ["Moderate"],
+                        "basis_year": [2030],
+                    }
+                )
+
+        s = _minimal_valid_settings(
+            new_resources=[["NaturalGas", "CCGT", "Moderate", 500]]
+        )
+        results = _check_new_resource_cost_years(s, FakeDM())
+        assert any(
+            "no matching rows found" in (r.detail or "") for r in _warnings(results)
+        )
+
+    def test_new_resource_cost_years_ellipsis_for_many_available_years(self):
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame(
+                    {
+                        "technology": ["NaturalGas"] * 8,
+                        "tech_detail": ["CCGT"] * 8,
+                        "cost_case": ["Moderate"] * 8,
+                        "basis_year": [2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017],
+                    }
+                )
+
+        s = _minimal_valid_settings(
+            new_resources=[["NaturalGas", "CCGT", "Moderate", 500]]
+        )
+        results = _check_new_resource_cost_years(s, FakeDM())
+        assert "…" in (_warnings(results)[0].detail or "")
 
 
 class TestCheckAggregationBaseRegions:
@@ -912,3 +1265,231 @@ class TestCheckAggregationBaseRegions:
         }
         results = _check_aggregation_base_regions(s, FakeDM())
         assert results == []
+
+    def test_non_list_aggregation_value_is_ignored(self):
+        class FakeDM:
+            available_tables = {"plant_region"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"region": ["p1"]})
+
+        s = {"model_regions": ["AZ"], "region_aggregations": {"AZ": "p1"}}
+        assert _check_aggregation_base_regions(s, FakeDM()) == []
+
+    def test_aggregation_base_regions_non_list_entry_ignored_when_unknown_exists(self):
+        class FakeDM:
+            available_tables = {"plant_region"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"region": ["p1"]})
+
+        s = {
+            "model_regions": ["AZ", "p2"],
+            "region_aggregations": {"AZ": "p1", "NM": ["q2"]},
+        }
+        warns = _warnings(_check_aggregation_base_regions(s, FakeDM()))
+        assert len(warns) == 1
+        assert "q2" in (warns[0].detail or "")
+
+    def test_aggregation_base_regions_handles_table_read_failures(self):
+        class FakeDM:
+            available_tables = {
+                "plant_region",
+                "demand",
+                "fuel_price",
+                "transmission_cost",
+            }
+
+            def get_data(self, *a, **kw):
+                raise RuntimeError("table read failed")
+
+        s = {"model_regions": ["AZ"], "region_aggregations": {"AZ": ["p1"]}}
+        assert _check_aggregation_base_regions(s, FakeDM()) == []
+
+
+def test_validate_settings_with_data_swallow_check_exception(monkeypatch):
+    import powergenome.validate as validate_mod
+
+    def bad_check(_settings, _dm):
+        raise RuntimeError("boom")
+
+    class FakeDM:
+        available_tables = set()
+
+    monkeypatch.setattr(validate_mod, "_PHASE2_CHECKS", [bad_check])
+    assert validate_settings_with_data(_minimal_valid_settings(), FakeDM()) == []
+
+
+class TestValidateCli:
+    def test_parse_validate_args_flags(self):
+        args = _parse_validate_args(
+            ["-sf", "settings", "--skip-data-checks", "--no-fail"]
+        )
+        assert args.settings_file == "settings"
+        assert args.skip_data_checks is True
+        assert args.no_fail is True
+
+    def test_validate_powergenome_exits_on_errors(self, monkeypatch):
+        import argparse
+
+        import powergenome.settings as settings_mod
+
+        class FakeSettings(dict):
+            def __init__(self, config_path):
+                super().__init__({"data_location": None})
+
+        monkeypatch.setattr(settings_mod, "Settings", FakeSettings)
+        monkeypatch.setattr(
+            "powergenome.validate._parse_validate_args",
+            lambda argv=None: argparse.Namespace(
+                settings_file="settings",
+                skip_data_checks=True,
+                no_fail=False,
+            ),
+        )
+        monkeypatch.setattr(
+            "powergenome.validate.validate_settings",
+            lambda _settings: [ValidationResult(ValidationLevel.ERROR, "x", "err")],
+        )
+        monkeypatch.setattr(
+            "powergenome.validate.report_validation_results",
+            lambda *_a, **_kw: None,
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            validate_powergenome()
+        assert exc.value.code == 1
+
+    def test_validate_powergenome_logs_when_phase2_skipped_for_no_data_location(
+        self, monkeypatch
+    ):
+        import argparse
+
+        import powergenome.settings as settings_mod
+
+        class FakeSettings(dict):
+            def __init__(self, config_path):
+                super().__init__({"data_location": None})
+
+        monkeypatch.setattr(settings_mod, "Settings", FakeSettings)
+        monkeypatch.setattr(
+            "powergenome.validate._parse_validate_args",
+            lambda argv=None: argparse.Namespace(
+                settings_file="settings",
+                skip_data_checks=False,
+                no_fail=True,
+            ),
+        )
+        monkeypatch.setattr(
+            "powergenome.validate.validate_settings", lambda _settings: []
+        )
+
+        validate_powergenome()
+
+    def test_validate_powergenome_runs_phase2_with_no_phase2_results(self, monkeypatch):
+        import argparse
+        import types
+
+        import powergenome.database as db_mod
+        import powergenome.settings as settings_mod
+
+        class FakeSettings(dict):
+            def __init__(self, config_path):
+                super().__init__({"data_location": "tests/test_system/test_data"})
+
+        monkeypatch.setattr(settings_mod, "Settings", FakeSettings)
+        monkeypatch.setattr(
+            "powergenome.validate._parse_validate_args",
+            lambda argv=None: argparse.Namespace(
+                settings_file="settings",
+                skip_data_checks=False,
+                no_fail=True,
+            ),
+        )
+        monkeypatch.setattr(
+            "powergenome.validate.validate_settings", lambda _settings: []
+        )
+        monkeypatch.setattr(
+            "powergenome.validate.validate_settings_with_data", lambda *_a: []
+        )
+        monkeypatch.setattr(
+            "powergenome.validate.report_validation_results", lambda *_a, **_kw: None
+        )
+        monkeypatch.setattr(db_mod, "_data_manager", types.SimpleNamespace())
+        monkeypatch.setattr(db_mod, "initialize_data_manager", lambda *_a, **_kw: None)
+
+        validate_powergenome()
+
+    def test_validate_powergenome_phase2_exception_sets_error(self, monkeypatch):
+        import argparse
+        import types
+
+        import powergenome.database as db_mod
+        import powergenome.settings as settings_mod
+
+        class FakeSettings(dict):
+            def __init__(self, config_path):
+                super().__init__({"data_location": "tests/test_system/test_data"})
+
+        monkeypatch.setattr(settings_mod, "Settings", FakeSettings)
+        monkeypatch.setattr(
+            "powergenome.validate._parse_validate_args",
+            lambda argv=None: argparse.Namespace(
+                settings_file="settings",
+                skip_data_checks=False,
+                no_fail=False,
+            ),
+        )
+        monkeypatch.setattr(
+            "powergenome.validate.validate_settings", lambda _settings: []
+        )
+        monkeypatch.setattr(db_mod, "_data_manager", types.SimpleNamespace())
+
+        def _boom(*_a, **_kw):
+            raise RuntimeError("init failed")
+
+        monkeypatch.setattr(db_mod, "initialize_data_manager", _boom)
+
+        with pytest.raises(SystemExit) as exc:
+            validate_powergenome()
+        assert exc.value.code == 1
+
+    def test_validate_powergenome_phase2_results_with_warnings_and_errors(
+        self, monkeypatch
+    ):
+        import argparse
+        import types
+
+        import powergenome.database as db_mod
+        import powergenome.settings as settings_mod
+
+        class FakeSettings(dict):
+            def __init__(self, config_path):
+                super().__init__({"data_location": "tests/test_system/test_data"})
+
+        monkeypatch.setattr(settings_mod, "Settings", FakeSettings)
+        monkeypatch.setattr(
+            "powergenome.validate._parse_validate_args",
+            lambda argv=None: argparse.Namespace(
+                settings_file="settings",
+                skip_data_checks=False,
+                no_fail=True,
+            ),
+        )
+        monkeypatch.setattr(
+            "powergenome.validate.validate_settings", lambda _settings: []
+        )
+        monkeypatch.setattr(
+            "powergenome.validate.validate_settings_with_data",
+            lambda *_a: [
+                ValidationResult(ValidationLevel.WARNING, "cat", "warn"),
+                ValidationResult(ValidationLevel.ERROR, "cat", "err"),
+            ],
+        )
+        monkeypatch.setattr(
+            "powergenome.validate.report_validation_results", lambda *_a, **_kw: None
+        )
+        monkeypatch.setattr(db_mod, "_data_manager", types.SimpleNamespace())
+        monkeypatch.setattr(db_mod, "initialize_data_manager", lambda *_a, **_kw: None)
+
+        validate_powergenome()

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -1,0 +1,914 @@
+"""
+Tests for powergenome.validate — settings and data validation module.
+
+Phase 1 tests use plain dicts and require no file I/O.
+Phase 2 tests use the test_system settings + DataManager.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from powergenome.validate import (
+    ValidationLevel,
+    ValidationResult,
+    _check_aggregation_base_regions,
+    _check_data_tables_loaded,
+    _check_fuel_consistency,
+    _check_fuel_price_coverage,
+    _check_model_tag_coverage,
+    _check_new_resource_cost_years,
+    _check_paths_exist,
+    _check_region_consistency,
+    _check_required_keys,
+    _check_transmission_regions,
+    _check_year_list_consistency,
+    _extract_planning_periods,
+    _tech_has_required_tag,
+    _tech_matches_any_key,
+    report_validation_results,
+    validate_settings,
+    validate_settings_with_data,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures / helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+TEST_SETTINGS_PATH = "tests/test_system/settings"
+TEST_DATA_PATH = "tests/test_system/test_data"
+
+
+def _errors(results):
+    return [r for r in results if r.level == ValidationLevel.ERROR]
+
+
+def _warnings(results):
+    return [r for r in results if r.level == ValidationLevel.WARNING]
+
+
+def _minimal_valid_settings(**overrides):
+    """Return a minimal settings dict that passes all Phase 1 checks (no paths)."""
+    base = {
+        "model_regions": ["RegionA", "RegionB"],
+        "target_usd_year": 2020,
+        "model_year": [2030],
+        "model_first_planning_year": [2025],
+        "model_tag_values": {
+            "THERM": {"NaturalGas": 1, "Coal": 1},
+            "VRE": {"Wind": 1, "Solar": 1},
+            "STOR": {"Battery": 1},
+            "MUST_RUN": {"Nuclear": 1},
+            "FLEX": {},
+            "HYDRO": {"Hydro": 1},
+        },
+        "fuel_scenarios": {"naturalgas": "reference", "coal": "reference"},
+        "tech_fuel_map": {"NaturalGas CC": "naturalgas", "Coal ST": "coal"},
+        "fuel_emission_factors": {"naturalgas": 0.05306, "coal": 0.09552},
+    }
+    base.update(overrides)
+    return base
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unit helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_planning_periods_model_periods_single():
+    s = {"model_periods": [2025, 2030]}
+    assert _extract_planning_periods(s) == [(2025, 2030)]
+
+
+def test_extract_planning_periods_model_periods_multi():
+    s = {"model_periods": [[2025, 2030], [2031, 2040]]}
+    assert _extract_planning_periods(s) == [(2025, 2030), (2031, 2040)]
+
+
+def test_extract_planning_periods_legacy():
+    s = {"model_year": [2030, 2040], "model_first_planning_year": [2025, 2031]}
+    assert _extract_planning_periods(s) == [(2025, 2030), (2031, 2040)]
+
+
+def test_extract_planning_periods_empty():
+    assert _extract_planning_periods({}) == []
+
+
+def test_tech_matches_any_key_positive():
+    tag_dict = {"NaturalGas": 1, "Wind": 1}
+    assert _tech_matches_any_key("NaturalGas_CCGT", tag_dict)
+    assert _tech_matches_any_key("naturalgas_ccgt", tag_dict)  # case-insensitive
+
+
+def test_tech_matches_any_key_negative():
+    tag_dict = {"NaturalGas": 1}
+    assert not _tech_matches_any_key("Battery_Lithium", tag_dict)
+
+
+def test_tech_has_required_tag_therm():
+    model_tag_values = {
+        "THERM": {"NaturalGas": 1},
+        "VRE": {},
+        "STOR": {},
+        "MUST_RUN": {},
+        "FLEX": {},
+        "HYDRO": {},
+    }
+    assert _tech_has_required_tag("NaturalGas_CCGT", model_tag_values)
+
+
+def test_tech_has_required_tag_no_match():
+    model_tag_values = {
+        "THERM": {"NaturalGas": 1},
+        "VRE": {},
+        "STOR": {},
+        "MUST_RUN": {},
+        "FLEX": {},
+        "HYDRO": {},
+    }
+    assert not _tech_has_required_tag("UnknownTech_v1", model_tag_values)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1 — _check_required_keys
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCheckRequiredKeys:
+    def test_valid_settings_no_errors(self):
+        s = {
+            "model_regions": ["r1"],
+            "target_usd_year": 2020,
+            "model_year": [2030],
+            "model_first_planning_year": [2025],
+        }
+        assert _errors(_check_required_keys(s)) == []
+
+    def test_valid_with_model_periods(self):
+        s = {
+            "model_regions": ["r1"],
+            "target_usd_year": 2020,
+            "model_periods": [[2025, 2030]],
+        }
+        assert _errors(_check_required_keys(s)) == []
+
+    def test_missing_model_regions(self):
+        s = {
+            "target_usd_year": 2020,
+            "model_year": [2030],
+            "model_first_planning_year": [2025],
+        }
+        results = _check_required_keys(s)
+        assert any("model_regions" in r.message for r in _errors(results))
+
+    def test_missing_target_usd_year(self):
+        s = {
+            "model_regions": ["r1"],
+            "model_year": [2030],
+            "model_first_planning_year": [2025],
+        }
+        results = _check_required_keys(s)
+        assert any("target_usd_year" in r.message for r in _errors(results))
+
+    def test_missing_all_planning_year_options(self):
+        s = {"model_regions": ["r1"], "target_usd_year": 2020}
+        results = _check_required_keys(s)
+        assert len(_errors(results)) >= 1
+        assert any("model_periods" in r.message for r in _errors(results))
+
+    def test_missing_only_model_first_planning_year(self):
+        """Has model_year but not model_first_planning_year → error about combined requirement."""
+        s = {"model_regions": ["r1"], "target_usd_year": 2020, "model_year": [2030]}
+        results = _check_required_keys(s)
+        assert len(_errors(results)) >= 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1 — _check_year_list_consistency
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCheckYearListConsistency:
+    def test_valid_legacy(self):
+        s = {"model_year": [2030, 2040], "model_first_planning_year": [2025, 2031]}
+        assert _check_year_list_consistency(s) == []
+
+    def test_valid_model_periods(self):
+        s = {"model_periods": [[2025, 2030], [2031, 2040]]}
+        assert _check_year_list_consistency(s) == []
+
+    def test_length_mismatch(self):
+        s = {"model_year": [2030, 2040], "model_first_planning_year": [2025]}
+        results = _check_year_list_consistency(s)
+        assert len(_errors(results)) == 1
+
+    def test_first_year_after_end_year(self):
+        s = {"model_year": [2030], "model_first_planning_year": [2035]}
+        results = _check_year_list_consistency(s)
+        assert len(_errors(results)) == 1
+
+    def test_model_periods_bad_entries(self):
+        s = {"model_periods": [[2025, 2030], [2040]]}  # second entry is length 1
+        results = _check_year_list_consistency(s)
+        assert len(_errors(results)) == 1
+
+    def test_model_periods_inverted(self):
+        s = {"model_periods": [[2040, 2030]]}  # first > last
+        results = _check_year_list_consistency(s)
+        assert len(_errors(results)) == 1
+
+    def test_valid_single_period(self):
+        s = {"model_periods": [2025, 2030]}  # flat single period
+        assert _check_year_list_consistency(s) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1 — _check_paths_exist
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCheckPathsExist:
+    def test_no_paths_configured(self):
+        assert _check_paths_exist({}) == []
+
+    def test_existing_data_location(self, tmp_path):
+        s = {"data_location": str(tmp_path)}
+        assert _errors(_check_paths_exist(s)) == []
+
+    def test_missing_data_location(self, tmp_path):
+        s = {"data_location": str(tmp_path / "no_such_folder")}
+        results = _check_paths_exist(s)
+        assert any("data_location" in r.message for r in _errors(results))
+
+    def test_missing_resource_groups(self, tmp_path):
+        s = {"RESOURCE_GROUPS": str(tmp_path / "does_not_exist")}
+        results = _check_paths_exist(s)
+        assert any("RESOURCE_GROUPS" in r.message for r in _errors(results))
+
+    def test_existing_input_folder_with_scenario_file(self, tmp_path):
+        scenario_file = tmp_path / "scenarios.csv"
+        scenario_file.write_text("case_id,year\nbaseline,2030\n")
+        s = {"input_folder": str(tmp_path), "scenario_definitions_fn": "scenarios.csv"}
+        assert _errors(_check_paths_exist(s)) == []
+
+    def test_missing_scenario_file(self, tmp_path):
+        s = {
+            "input_folder": str(tmp_path),
+            "scenario_definitions_fn": "missing_scenarios.csv",
+        }
+        results = _check_paths_exist(s)
+        assert any("scenario_definitions_fn" in r.message for r in _errors(results))
+
+    def test_missing_input_folder(self, tmp_path):
+        s = {"input_folder": str(tmp_path / "no_folder")}
+        results = _check_paths_exist(s)
+        assert any("input_folder" in r.message for r in _errors(results))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1 — _check_region_consistency
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCheckRegionConsistency:
+    def test_no_region_settings(self):
+        s = {"model_regions": ["r1", "r2"]}
+        assert _check_region_consistency(s) == []
+
+    def test_valid_regional_tag_values(self):
+        s = {
+            "model_regions": ["r1", "r2"],
+            "regional_tag_values": {"r1": {"THERM": {"Coal": 1}}, "r2": {}},
+        }
+        assert _warnings(_check_region_consistency(s)) == []
+
+    def test_unknown_region_in_regional_tag_values(self):
+        s = {
+            "model_regions": ["r1", "r2"],
+            "regional_tag_values": {"r1": {}, "r_unknown": {}},
+        }
+        results = _check_region_consistency(s)
+        assert any("regional_tag_values" in r.message for r in _warnings(results))
+        assert any(
+            "r_unknown" in (r.message + (r.detail or "")) for r in _warnings(results)
+        )
+
+    def test_unknown_region_in_alt_num_clusters(self):
+        s = {
+            "model_regions": ["r1"],
+            "alt_num_clusters": {"r1": {"Coal": 2}, "r_bad": {"Coal": 1}},
+        }
+        results = _check_region_consistency(s)
+        assert any("alt_num_clusters" in r.message for r in _warnings(results))
+
+    def test_unknown_region_in_regional_capacity_reserves(self):
+        s = {
+            "model_regions": ["r1", "r2"],
+            "regional_capacity_reserves": {"CapRes_1": {"r1": 0.15, "r_unknown": 0.15}},
+        }
+        results = _check_region_consistency(s)
+        assert any(
+            "regional_capacity_reserves" in r.message for r in _warnings(results)
+        )
+
+    def test_unknown_small_hydro_region(self):
+        s = {
+            "model_regions": ["r1", "r2"],
+            "small_hydro_regions": ["r1", "r_ghost"],
+        }
+        results = _check_region_consistency(s)
+        assert any("small_hydro_regions" in r.message for r in _warnings(results))
+
+    def test_all_regions_valid(self):
+        s = {
+            "model_regions": ["r1", "r2"],
+            "regional_hydro_factor": {"r1": 4, "r2": 4},
+            "distributed_gen_method": {"r1": "capacity", "r2": "capacity"},
+        }
+        assert _warnings(_check_region_consistency(s)) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1 — _check_model_tag_coverage
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCheckModelTagCoverage:
+    def test_no_new_resources(self):
+        s = _minimal_valid_settings(new_resources=None)
+        assert _check_model_tag_coverage(s) == []
+
+    def test_with_tagged_resources(self):
+        s = _minimal_valid_settings(
+            new_resources=[
+                ["NaturalGas", "CCGT", "Moderate", 500],
+                ["Wind", "Class3", "Moderate", 1],
+                ["Battery", "LithiumIon", "Moderate", 1],
+            ]
+        )
+        assert _warnings(_check_model_tag_coverage(s)) == []
+
+    def test_untagged_resource(self):
+        s = _minimal_valid_settings(
+            new_resources=[["UnknownTech", "v1", "Moderate", 100]]
+        )
+        results = _check_model_tag_coverage(s)
+        assert any("UnknownTech_v1" in (r.detail or "") for r in _warnings(results))
+
+    def test_no_model_tag_values(self):
+        """If model_tag_values is absent we skip the check (no false positives)."""
+        s = _minimal_valid_settings(model_tag_values=None)
+        assert _check_model_tag_coverage(s) == []
+
+    def test_modified_new_resources_untagged(self):
+        s = _minimal_valid_settings(
+            modified_new_resources={
+                "MyCustomTech": {
+                    "new_technology": "Zeppelin",
+                    "new_tech_detail": "v1",
+                }
+            }
+        )
+        results = _check_model_tag_coverage(s)
+        assert any("Zeppelin" in (r.detail or "") for r in _warnings(results))
+
+    def test_modified_new_resources_tagged(self):
+        s = _minimal_valid_settings(
+            modified_new_resources={
+                "MyWind": {
+                    "new_technology": "Wind",
+                    "new_tech_detail": "Class3",
+                }
+            }
+        )
+        assert _warnings(_check_model_tag_coverage(s)) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1 — _check_fuel_consistency
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCheckFuelConsistency:
+    def test_valid(self):
+        s = _minimal_valid_settings()
+        assert _check_fuel_consistency(s) == []
+
+    def test_fuel_not_in_fuel_scenarios(self):
+        s = _minimal_valid_settings(
+            tech_fuel_map={"SomeGen": "hydrogen"},
+            fuel_scenarios={"naturalgas": "ref"},
+        )
+        results = _check_fuel_consistency(s)
+        assert any("hydrogen" in r.message for r in _warnings(results))
+
+    def test_fuel_in_user_fuel_price_ok(self):
+        s = _minimal_valid_settings(
+            tech_fuel_map={"SomeGen": "hydrogen"},
+            fuel_scenarios={},
+            user_fuel_price={"hydrogen": 10.0},
+        )
+        assert _warnings(_check_fuel_consistency(s)) == []
+
+    def test_ccs_missing_capture_rate(self):
+        s = _minimal_valid_settings(
+            ccs_fuel_map={"NaturalGas_CCS90": "naturalgas_ccs90"},
+            ccs_capture_rate={},  # missing entry
+        )
+        results = _check_fuel_consistency(s)
+        assert any("ccs_capture_rate" in r.message for r in _warnings(results))
+
+    def test_ccs_with_capture_rate_ok(self):
+        s = _minimal_valid_settings(
+            ccs_fuel_map={"NaturalGas_CCS90": "naturalgas_ccs90"},
+            ccs_capture_rate={"naturalgas_ccs90": 0.9},
+            fuel_emission_factors={"naturalgas": 0.05306, "coal": 0.09552},
+        )
+        assert _warnings(_check_fuel_consistency(s)) == []
+
+    def test_ccs_missing_base_fuel_emission_factor(self):
+        s = _minimal_valid_settings(
+            ccs_fuel_map={"CoalCCS": "coal_ccs90"},
+            ccs_capture_rate={"coal_ccs90": 0.9},
+            fuel_emission_factors={},  # no 'coal' entry
+        )
+        results = _check_fuel_consistency(s)
+        assert any("fuel_emission_factors" in r.message for r in _warnings(results))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1 — validate_settings (integration)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestValidateSettings:
+    def test_minimal_valid_dict_no_issues(self):
+        """A well-formed minimal settings dict should produce no results."""
+        results = validate_settings(_minimal_valid_settings())
+        # Path checks may produce errors if actual paths aren't set, but
+        # we haven't set any paths, so there should be no path errors.
+        path_errors = [r for r in results if r.category == "paths"]
+        assert path_errors == []
+
+    def test_empty_settings_produces_errors(self):
+        results = validate_settings({})
+        assert len(_errors(results)) >= 1  # at least required-key errors
+
+    def test_accepts_settings_object(self):
+        from powergenome.settings import Settings
+
+        s = Settings.from_dict(_minimal_valid_settings())
+        results = validate_settings(s)
+        path_errors = [r for r in results if r.category == "paths"]
+        assert path_errors == []
+
+    def test_unknown_region_produces_warning(self):
+        s = _minimal_valid_settings(
+            regional_tag_values={"RegionA": {}, "Unknown_Region": {}}
+        )
+        results = validate_settings(s)
+        # RegionA is valid, Unknown_Region is not
+        assert any(
+            r.level == ValidationLevel.WARNING and "region_consistency" == r.category
+            for r in results
+        )
+
+    def test_mismatched_year_lengths_error(self):
+        s = _minimal_valid_settings(
+            model_year=[2030, 2040],
+            model_first_planning_year=[2025],  # wrong length
+        )
+        results = validate_settings(s)
+        assert any(
+            r.level == ValidationLevel.ERROR and "planning_years" == r.category
+            for r in results
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# report_validation_results
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestReportValidationResults:
+    def test_empty_results_no_raise(self):
+        report_validation_results([])  # should not raise
+
+    def test_warnings_only_no_raise(self):
+        results = [ValidationResult(ValidationLevel.WARNING, "test", "a warning")]
+        report_validation_results(results)  # should not raise
+
+    def test_error_raises_by_default(self):
+        results = [ValidationResult(ValidationLevel.ERROR, "test", "an error")]
+        with pytest.raises(ValueError, match="1 error"):
+            report_validation_results(results)
+
+    def test_error_no_raise_when_disabled(self):
+        results = [ValidationResult(ValidationLevel.ERROR, "test", "an error")]
+        report_validation_results(results, raise_on_error=False)  # must not raise
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 2 tests (require DataManager + test data)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def test_settings():
+    """Load the test system settings with paths pointing at test data."""
+    from powergenome.settings import Settings
+
+    settings = Settings(config_path=TEST_SETTINGS_PATH)
+    settings["RESOURCE_GROUPS"] = str(Path(TEST_DATA_PATH) / "resource_groups")
+    settings["data_location"] = TEST_DATA_PATH
+    settings["cache_resource_clusters"] = False
+    settings["use_resource_clusters_cache"] = False
+    return settings
+
+
+@pytest.fixture(scope="module")
+def initialized_dm(test_settings):
+    """Initialize DataManager with test data once for the module."""
+    from powergenome.database import _data_manager, initialize_data_manager
+
+    initialize_data_manager(test_settings, test_settings["data_location"])
+    return _data_manager
+
+
+class TestPhase2WithTestData:
+    def test_transmission_regions_no_spurious_warnings(
+        self, test_settings, initialized_dm
+    ):
+        """Test system network_costs_test_data.csv should have no unknown regions."""
+        results = _check_transmission_regions(test_settings.to_dict(), initialized_dm)
+        assert (
+            _warnings(results) == []
+        ), f"Unexpected transmission region warnings: {results}"
+
+    def test_fuel_price_coverage_skips_if_table_absent(self):
+        """If fuel_price table is not loaded, the check should silently skip."""
+
+        class FakeDM:
+            available_tables = set()  # no fuel_price table
+
+        s = _minimal_valid_settings()
+        results = _check_fuel_price_coverage(s, FakeDM())
+        assert results == []
+
+    def test_new_resource_cost_years_skips_if_table_absent(self):
+        """If resource_cost table is not loaded, the check should silently skip."""
+
+        class FakeDM:
+            available_tables = set()
+
+        s = _minimal_valid_settings(
+            new_resources=[["NaturalGas", "CCGT", "Moderate", 500]]
+        )
+        results = _check_new_resource_cost_years(s, FakeDM())
+        assert results == []
+
+    def test_new_resource_cost_years_warns_on_no_overlap(self):
+        """A resource with no basis_year in the planning range should warn."""
+        import pandas as pd
+
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                return pd.DataFrame(
+                    {
+                        "technology": ["NaturalGas"],
+                        "tech_detail": ["CCGT"],
+                        "cost_case": ["Moderate"],
+                        "basis_year": [2010],  # out of range for 2025-2030 period
+                    }
+                )
+
+        s = _minimal_valid_settings(
+            new_resources=[["NaturalGas", "CCGT", "Moderate", 500]]
+        )
+        results = _check_new_resource_cost_years(s, FakeDM())
+        assert any(
+            "NaturalGas/CCGT/Moderate" in (r.detail or "") for r in _warnings(results)
+        )
+
+    def test_new_resource_cost_years_no_warning_when_overlap(self):
+        """A resource with a matching basis_year should produce no warning."""
+        import pandas as pd
+
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                return pd.DataFrame(
+                    {
+                        "technology": ["NaturalGas"],
+                        "tech_detail": ["CCGT"],
+                        "cost_case": ["Moderate"],
+                        "basis_year": [2028],  # within 2025-2030
+                    }
+                )
+
+        s = _minimal_valid_settings(
+            new_resources=[["NaturalGas", "CCGT", "Moderate", 500]]
+        )
+        results = _check_new_resource_cost_years(s, FakeDM())
+        assert _warnings(results) == []
+
+    def test_transmission_regions_warns_on_unknown(self):
+        """Unknown region in transmission table should produce a WARNING."""
+        import pandas as pd
+
+        class FakeDM:
+            available_tables = {"transmission_cost"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                return pd.DataFrame(
+                    {
+                        "start_region": ["RegionA", "UNKNOWN_REGION"],
+                        "dest_region": ["RegionB", "RegionA"],
+                    }
+                )
+
+        s = _minimal_valid_settings()  # model_regions = ["RegionA", "RegionB"]
+        results = _check_transmission_regions(s, FakeDM())
+        assert any("UNKNOWN_REGION" in (r.detail or "") for r in _warnings(results))
+
+    def test_transmission_regions_no_warning_for_base_ipm_regions(self):
+        """Base IPM regions from region_aggregations should be considered valid."""
+        import pandas as pd
+
+        class FakeDM:
+            available_tables = {"transmission_cost"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                # p1 is a base region of p1_2; should not trigger a warning
+                return pd.DataFrame({"start_region": ["p1"], "dest_region": ["p2"]})
+
+        s = {
+            "model_regions": ["p1_2", "p3", "p4"],
+            "region_aggregations": {"p1_2": ["p1", "p2"]},
+            "target_usd_year": 2020,
+            "model_year": [2030],
+            "model_first_planning_year": [2025],
+        }
+        results = _check_transmission_regions(s, FakeDM())
+        assert _warnings(results) == []
+
+    def test_fuel_price_coverage_warns_on_missing(self):
+        """Missing fuel/year/region combination should produce a WARNING."""
+        import pandas as pd
+
+        class FakeDM:
+            available_tables = {"fuel_price"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                # Only has 'coal' for year 2030 in RegionA — missing naturalgas
+                return pd.DataFrame(
+                    {
+                        "year": [2030],
+                        "fuel": ["coal"],
+                        "region": ["RegionA"],
+                        "scenario": ["reference"],
+                    }
+                )
+
+        s = _minimal_valid_settings(
+            fuel_scenarios={"coal": "reference", "naturalgas": "reference"}
+        )
+        results = _check_fuel_price_coverage(s, FakeDM())
+        warns = _warnings(results)
+        assert len(warns) == 1
+        assert "fuel_price_coverage" == warns[0].category
+        # naturalgas/reference/RegionA/2030 and naturalgas/reference/RegionB/2030 missing
+        # coal/reference/RegionB/2030 also missing
+        assert "naturalgas" in (warns[0].detail or "")
+
+    def test_data_tables_loaded_error_on_missing(self):
+        """If a configured table is absent from DataManager, flag as ERROR."""
+
+        class FakeDM:
+            available_tables = set()  # nothing loaded
+
+        s = {"resource_cost_table": "myfile.csv"}
+        results = _check_data_tables_loaded(s, FakeDM())
+        assert any("resource_cost_table" in r.message for r in _errors(results))
+
+    def test_data_tables_loaded_no_error_when_present(self):
+        """A table present in available_tables should produce no error."""
+
+        class FakeDM:
+            available_tables = {"resource_cost"}
+
+        s = {"resource_cost_table": "myfile.csv"}
+        results = _check_data_tables_loaded(s, FakeDM())
+        assert _errors(results) == []
+
+    def test_validate_settings_with_data_integration(
+        self, test_settings, initialized_dm
+    ):
+        """Full Phase 2 run on test system should not raise (warnings are OK)."""
+        results = validate_settings_with_data(test_settings, initialized_dm)
+        # Report without raising errors so we can inspect
+        report_validation_results(results, raise_on_error=False)
+        # The test system should have no ERROR-level issues in Phase 2
+        assert _errors(results) == [], f"Unexpected data errors: {_errors(results)}"
+
+
+class TestCheckAggregationBaseRegions:
+    """Tests for _check_aggregation_base_regions."""
+
+    def test_no_regions_at_all_skipped(self):
+        """Settings with neither model_regions nor region_aggregations → no results."""
+
+        class FakeDM:
+            available_tables = {"plant_region"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"region": ["p1", "p2"]})
+
+        results = _check_aggregation_base_regions({}, FakeDM())
+        assert results == []
+
+    def test_passthrough_model_region_valid(self):
+        """A pass-through model region present in data → no warning."""
+
+        class FakeDM:
+            available_tables = {"plant_region"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"region": ["p1", "p2", "p3"]})
+
+        # p3 is a pass-through (not in region_aggregations)
+        s = {
+            "model_regions": ["p1_2", "p3"],
+            "region_aggregations": {"p1_2": ["p1", "p2"]},
+        }
+        results = _check_aggregation_base_regions(s, FakeDM())
+        assert results == []
+
+    def test_passthrough_model_region_typo_detected(self):
+        """A pass-through model region absent from all tables → WARNING."""
+
+        class FakeDM:
+            available_tables = {"plant_region"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"region": ["p1", "p2", "p3"]})
+
+        # q2 is a typo; listed directly in model_regions without an aggregation entry
+        s = {
+            "model_regions": ["p1_2", "q2"],
+            "region_aggregations": {"p1_2": ["p1", "p2"]},
+        }
+        results = _check_aggregation_base_regions(s, FakeDM())
+        warns = _warnings(results)
+        assert len(warns) == 1
+        assert warns[0].category == "aggregation_base_regions"
+        assert "q2" in (warns[0].detail or "")
+        assert "pass-through" in (warns[0].detail or "")
+
+    def test_no_region_aggregations_passthrough_checked(self):
+        """With no region_aggregations, pass-through model_regions are still checked."""
+
+        class FakeDM:
+            available_tables = {"plant_region"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"region": ["p1", "p2"]})
+
+        # q3 is a typo in a pure pass-through setup (no aggregations at all)
+        s = {"model_regions": ["p1", "q3"]}
+        results = _check_aggregation_base_regions(s, FakeDM())
+        warns = _warnings(results)
+        assert len(warns) == 1
+        assert "q3" in (warns[0].detail or "")
+
+    def test_all_base_regions_valid(self):
+        """All base regions present in plant_region table → no warning."""
+
+        class FakeDM:
+            available_tables = {"plant_region"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"region": ["p1", "p2", "p3"]})
+
+        s = {
+            "model_regions": ["p1_2", "p3"],
+            "region_aggregations": {"p1_2": ["p1", "p2"], "p3": ["p3"]},
+        }
+        results = _check_aggregation_base_regions(s, FakeDM())
+        assert results == []
+
+    def test_typo_region_detected(self):
+        """Base region 'q2' (typo for 'p2') absent from all tables → WARNING."""
+
+        class FakeDM:
+            available_tables = {"plant_region"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"region": ["p1", "p2", "p3"]})
+
+        s = {
+            "model_regions": ["AZ"],
+            "region_aggregations": {"AZ": ["p1", "q2"]},  # q2 is a typo
+        }
+        results = _check_aggregation_base_regions(s, FakeDM())
+        warns = _warnings(results)
+        assert len(warns) == 1
+        assert warns[0].category == "aggregation_base_regions"
+        assert "q2" in (warns[0].detail or "")
+
+    def test_region_found_in_demand_not_plant_region(self):
+        """Region present in demand but absent from plant_region → no warning."""
+
+        class FakeDM:
+            available_tables = {"plant_region", "demand"}
+
+            def get_data(self, table_name, columns=None, **kwargs):
+                if table_name == "plant_region":
+                    return pd.DataFrame({"region": ["p1"]})
+                if table_name == "demand":
+                    return pd.DataFrame({"region": ["p1", "p2"]})
+                return pd.DataFrame()
+
+        s = {
+            "model_regions": ["p1_2"],
+            "region_aggregations": {"p1_2": ["p1", "p2"]},
+        }
+        results = _check_aggregation_base_regions(s, FakeDM())
+        assert results == []
+
+    def test_no_available_tables_skipped_gracefully(self):
+        """If no relevant data tables are loaded, the check is skipped silently."""
+
+        class FakeDM:
+            available_tables = set()
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame()
+
+        s = {
+            "model_regions": ["AZ"],
+            "region_aggregations": {"AZ": ["p1", "q999"]},
+        }
+        results = _check_aggregation_base_regions(s, FakeDM())
+        assert results == []
+
+    def test_detail_identifies_offending_model_region(self):
+        """Detail string should name which model region maps to the bad base region."""
+
+        class FakeDM:
+            available_tables = {"plant_region"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"region": ["p1", "p2"]})
+
+        s = {
+            "model_regions": ["AZ", "NM"],
+            "region_aggregations": {
+                "AZ": ["p1", "p2"],  # valid
+                "NM": ["p3", "TYPO_REGION"],  # typo
+            },
+        }
+        results = _check_aggregation_base_regions(s, FakeDM())
+        warns = _warnings(results)
+        assert len(warns) == 1
+        assert "NM" in (warns[0].detail or "")
+        assert "TYPO_REGION" in (warns[0].detail or "")
+        assert "AZ" not in (warns[0].detail or "")
+
+    def test_region_found_in_fuel_price_table(self):
+        """Region present only in fuel_price table → no warning."""
+
+        class FakeDM:
+            available_tables = {"fuel_price"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"region": ["p1", "p2"]})
+
+        s = {
+            "model_regions": ["p1_2"],
+            "region_aggregations": {"p1_2": ["p1", "p2"]},
+        }
+        results = _check_aggregation_base_regions(s, FakeDM())
+        assert results == []
+
+    def test_region_found_in_transmission_table(self):
+        """Region present only in transmission_cost table → no warning."""
+
+        class FakeDM:
+            available_tables = {"transmission_cost"}
+
+            def get_data(self, *a, **kw):
+                return pd.DataFrame({"start_region": ["p1"], "dest_region": ["p2"]})
+
+        s = {
+            "model_regions": ["p1_2"],
+            "region_aggregations": {"p1_2": ["p1", "p2"]},
+        }
+        results = _check_aggregation_base_regions(s, FakeDM())
+        assert results == []


### PR DESCRIPTION
This pull request introduces a built-in settings validation system to PowerGenome, improves documentation to explain validation and debugging workflows, and adds a new CLI command for standalone validation. The most important changes are the addition of settings validation functionality, updates to the documentation to guide users, and enhancements to the CLI interface.

**Validation system integration:**

* Added `validate_powergenome` CLI command for standalone validation of settings and data, including support for phase-specific checks and CI-friendly exit codes. (`pyproject.toml`, `powergenome/validate.py`)
* Integrated two-phase validation (settings-only and settings-vs-data) into the `run_powergenome` workflow, logging results before pipeline execution. (`powergenome/run_powergenome.py`) [[1]](diffhunk://#diff-acaa864d1add77685219104f67de518620679198153e959117d300252372820dR46-R50) [[2]](diffhunk://#diff-acaa864d1add77685219104f67de518620679198153e959117d300252372820dR177-R187)

**Documentation updates:**

* Created a comprehensive guide for settings validation, detailing how the checks work, common issues, and troubleshooting steps. (`docs/how-to/validate-settings.md`)
* Updated CLI reference docs to describe both `run_powergenome` and `validate_powergenome`, including usage, flags, and exit codes. (`docs/reference/cli.md`) [[1]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711L3-R20) [[2]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711L170-R231)
* Added validation and debugging section to the "How To" index and navigation, making guides easier to find. (`docs/how-to/index.md`, `mkdocs.yml`) [[1]](diffhunk://#diff-a62277b14aab6742697a72ebe63db2be1ea5ba095495f9c7a425d9fc7b6e8f18R13-R17) [[2]](diffhunk://#diff-a62277b14aab6742697a72ebe63db2be1ea5ba095495f9c7a425d9fc7b6e8f18R35) [[3]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R105)

**Testing improvements:**

* Patched CLI tests to bypass validation logic, ensuring test isolation and preventing failures due to mock settings objects. (`tests/cli_test.py`)