### PR TITLE
Support multiple data locations relative to settings

### DIFF
--- a/docs/how-to/configure-data-tables.md
+++ b/docs/how-to/configure-data-tables.md
@@ -20,7 +20,19 @@ Tell PowerGenome where your data files live with `data_location`:
 data_location: /path/to/your/data_folder # Can also be /path/to/database.db
 ```
 
-This is the base path used for all table lookups. All filenames in table settings are resolved relative to this folder.
+Paths may be relative to the settings file (or settings directory), and multiple
+locations may be provided:
+
+```yaml
+data_location:
+  - data
+  - /shared/powergenome_data.db
+input_folder: extra_inputs
+```
+
+PowerGenome searches `input_folder` as well as `data_location` for configured
+tables. Each table must be found in exactly one location; duplicate table names
+are rejected.
 
 ---
 
@@ -37,7 +49,7 @@ fuel_price_table: fuel_prices.csv
 transmission_constraints_table: transmission_constraints.csv
 ```
 
-PowerGenome resolves each filename inside `data_location`.
+PowerGenome resolves each filename inside the configured data locations.
 
 ### Advanced configuration (with filters)
 

--- a/powergenome/database.py
+++ b/powergenome/database.py
@@ -114,7 +114,9 @@ class DataManager:
         self.connection = duckdb.connect(database=":memory:")
         self.settings = self._convert_settings_to_dict(settings)
         if data_location:
-            locations = data_location if isinstance(data_location, list) else [data_location]
+            locations = (
+                data_location if isinstance(data_location, list) else [data_location]
+            )
             self._data_locations = [Path(location) for location in locations]
         else:
             self._data_locations = []
@@ -132,9 +134,7 @@ class DataManager:
         self.data_location = (
             self._data_locations[0]
             if len(self._data_locations) == 1
-            else self._data_locations
-            if self._data_locations
-            else None
+            else self._data_locations if self._data_locations else None
         )
         self.lazy_loading = lazy_loading
         self.table_configurations = {}  # Reset configurations
@@ -394,7 +394,9 @@ class DataManager:
                         f"ATTACH '{str(data_location).replace(chr(39), chr(39) * 2)}' AS {alias}"
                     )
                     self._attached_databases[data_location] = alias
-                source_query = f"{self._attached_databases[data_location]}.{source_table}"
+                source_query = (
+                    f"{self._attached_databases[data_location]}.{source_table}"
+                )
             else:
                 raise ValueError("Unsupported database type")
 

--- a/powergenome/database.py
+++ b/powergenome/database.py
@@ -77,6 +77,10 @@ class DataManager:
                 if not self._initialized:
                     self.connection = None
                     self.data_location = None
+                    self._data_locations = []
+                    self._table_locations = {}
+                    self._attached_databases = {}
+                    self._database_tables = {}
                     self.available_tables = set()
                     self.table_configurations = {}  # Store original table configs
                     self._initialized = True
@@ -86,7 +90,7 @@ class DataManager:
     def initialize(
         self,
         settings: Union[Dict[str, Any], Settings],
-        data_location: Union[Path, str] = None,
+        data_location: Union[Path, str, List[Union[Path, str]]] = None,
         lazy_loading: bool = True,
     ):
         """
@@ -96,8 +100,9 @@ class DataManager:
         ----------
         settings : Union[Dict[str, Any], Settings]
             Settings dictionary or Settings object containing table configuration parameters
-        data_location : Union[Path, str], optional
-            Path to database file or folder containing data files
+        data_location : Union[Path, str, List[Union[Path, str]]], optional
+            Path(s) to database file(s) or folder(s) containing data files. Each
+            configured table must exist in exactly one location.
         lazy_loading : bool, optional
             If True, create views instead of loading all data into memory, by default True
         """
@@ -107,10 +112,35 @@ class DataManager:
 
         # Create in-memory DuckDB connection
         self.connection = duckdb.connect(database=":memory:")
-        self.data_location = Path(data_location) if data_location else None
         self.settings = self._convert_settings_to_dict(settings)
+        if data_location:
+            locations = data_location if isinstance(data_location, list) else [data_location]
+            self._data_locations = [Path(location) for location in locations]
+        else:
+            self._data_locations = []
+
+        input_folder = self.settings.get("input_folder")
+        if input_folder:
+            input_locations = (
+                input_folder if isinstance(input_folder, list) else [input_folder]
+            )
+            for location in input_locations:
+                location = Path(location)
+                if location not in self._data_locations:
+                    self._data_locations.append(location)
+
+        self.data_location = (
+            self._data_locations[0]
+            if len(self._data_locations) == 1
+            else self._data_locations
+            if self._data_locations
+            else None
+        )
         self.lazy_loading = lazy_loading
         self.table_configurations = {}  # Reset configurations
+        self._table_locations = {}
+        self._attached_databases = {}
+        self._database_tables = {}
 
         # Setup tables based on settings
         self._setup_tables()
@@ -245,47 +275,69 @@ class DataManager:
                     normalized.append(clause_conds)
                 filters = normalized
 
-        # Validate file/table name format based on data location type
-        if self.data_location and self.data_location.is_dir():
-            # For folder-based data, require file extension
-            if not any(
-                source_table.lower().endswith(ext) for ext in [".csv", ".parquet"]
-            ):
-                logger.warning(
-                    f"Table '{standard_name}' source '{source_table}' does not have a "
-                    "file extension (.csv or .parquet). This may cause loading issues."
+        # Resolve the table against exactly one configured data source.
+        if self._data_locations:
+            matches = []
+            for location in self._data_locations:
+                resolved = self._resolve_table_source(location, source_table)
+                if resolved is not None:
+                    matches.append((location, resolved))
+
+            if len(matches) > 1:
+                locations = ", ".join(str(location) for location, _ in matches)
+                raise ValueError(
+                    f"Table '{standard_name}' source '{source_table}' was found in "
+                    f"multiple data locations: {locations}"
+                )
+            if not matches:
+                raise ValueError(
+                    f"Table '{standard_name}' source '{source_table}' was not found in "
+                    f"any data location: {', '.join(map(str, self._data_locations))}"
                 )
 
-                # Attempt to auto-detect the correct file
-                csv_path = self.data_location / f"{source_table}.csv"
-                parquet_path = self.data_location / f"{source_table}.parquet"
-
-                if csv_path.exists():
-                    logger.info(f"Auto-detected CSV file: {csv_path}")
-                    source_table = f"{source_table}.csv"
-                elif parquet_path.exists():
-                    logger.info(f"Auto-detected Parquet file: {parquet_path}")
-                    source_table = f"{source_table}.parquet"
-                else:
-                    raise ValueError(
-                        f"Table '{standard_name}' source '{source_table}' does not have a "
-                        f"file extension and no matching .csv or .parquet file was found in "
-                        f"{self.data_location}"
-                    )
-
-        elif self.data_location and self.data_location.is_file():
-            # For database files, table names should not have extensions
-            if any(
-                source_table.lower().endswith(ext)
-                for ext in [".csv", ".parquet", ".db", ".sqlite", ".duckdb"]
-            ):
-                logger.warning(
-                    f"Table '{standard_name}' source '{source_table}' appears to have a "
-                    "file extension, but data_location is a database file. "
-                    "Table names in databases should not have extensions."
-                )
+            location, source_table = matches[0]
+            self._table_locations[standard_name] = location
 
         return source_table, filters, columns
+
+    def _resolve_table_source(self, location: Path, source_table: str):
+        """Return the source file/table name if it exists at a location."""
+        if location.is_dir():
+            candidate = location / source_table
+            if candidate.is_file():
+                return source_table
+            if Path(source_table).suffix == "":
+                logger.warning(
+                    f"Table source '{source_table}' does not have a file extension "
+                    "(.csv or .parquet). This may cause loading issues."
+                )
+                for extension in (".csv", ".parquet"):
+                    if (location / f"{source_table}{extension}").is_file():
+                        file_type = "CSV" if extension == ".csv" else "Parquet"
+                        logger.info(
+                            f"Auto-detected {file_type} file: "
+                            f"{location / f'{source_table}{extension}'}"
+                        )
+                        return f"{source_table}{extension}"
+            return None
+
+        if not location.is_file():
+            return None
+        if location.suffix.lower() not in (".db", ".sqlite", ".duckdb"):
+            return None
+        if Path(source_table).suffix:
+            logger.warning(
+                f"Table source '{source_table}' appears to have a file extension, "
+                "but data_location is a database file. Table names in databases "
+                "should not have extensions."
+            )
+            return None
+        if location not in self._database_tables:
+            self._database_tables[location] = get_all_table_names(location)
+        return source_table if source_table in self._database_tables[location] else None
+
+    def _location_for_table(self, standard_name: str) -> Path:
+        return self._table_locations.get(standard_name, self.data_location)
 
     def _create_table_view(self, table_config: Union[str, Dict], standard_name: str):
         """
@@ -319,9 +371,10 @@ class DataManager:
         columns: List[str] = None,
     ):
         """Create a view that references external data without loading it into memory."""
-        if self.data_location.is_dir():
+        data_location = self._location_for_table(standard_name)
+        if data_location.is_dir():
             # For file-based data
-            file_path = self.data_location / source_table
+            file_path = data_location / source_table
             file_extension = file_path.suffix.lower()
 
             if file_extension == ".csv":
@@ -333,24 +386,15 @@ class DataManager:
 
         else:
             # For database files
-            if str(self.data_location).endswith((".db", ".sqlite")):
+            if str(data_location).endswith((".db", ".sqlite", ".duckdb")):
                 # Attach SQLite database and reference the table
-                if self.sqlite_attached is False:
+                if data_location not in self._attached_databases:
+                    alias = f"source_db_{len(self._attached_databases)}"
                     self.connection.execute(
-                        f"ATTACH '{self.data_location}' AS source_db"
+                        f"ATTACH '{str(data_location).replace(chr(39), chr(39) * 2)}' AS {alias}"
                     )
-                    self.sqlite_attached = True
-
-                source_query = f"source_db.{source_table}"
-            elif str(self.data_location).endswith(".duckdb"):
-                # For DuckDB files, also use ATTACH method
-                if self.duckdb_attached is False:
-                    self.connection.execute(
-                        f"ATTACH '{self.data_location}' AS source_db"
-                    )
-                    self.duckdb_attached = True
-
-                source_query = f"source_db.{source_table}"
+                    self._attached_databases[data_location] = alias
+                source_query = f"{self._attached_databases[data_location]}.{source_table}"
             else:
                 raise ValueError("Unsupported database type")
 
@@ -369,9 +413,10 @@ class DataManager:
         columns: List[str] = None,
     ):
         """Create a materialized table by loading all data into memory (original behavior)."""
-        if self.data_location:
+        data_location = self._location_for_table(standard_name)
+        if data_location:
             df = load_data(
-                data_location=self.data_location,
+                data_location=data_location,
                 file_or_table_name=source_table,
                 filters=filters,
                 columns=columns,

--- a/powergenome/run_powergenome.py
+++ b/powergenome/run_powergenome.py
@@ -222,8 +222,7 @@ def main(**kwargs):
     #         "are either in IPM or region_aggregations in the settings YAML file."
     #     )
 
-    input_folder = Path(args.settings_file).parent / Path(settings["input_folder"]).name
-    settings["input_folder"] = input_folder
+    input_folder = Path(settings["input_folder"])
 
     has_scenario_definitions = bool(settings.get("scenario_definitions_fn"))
 

--- a/powergenome/run_powergenome.py
+++ b/powergenome/run_powergenome.py
@@ -44,6 +44,7 @@ from powergenome.util import (  # init_pudl_connection,; check_settings,; load_i
     write_results_file,
 )
 from powergenome.validate import (
+    _extract_planning_periods,
     report_validation_results,
     validate_settings,
     validate_settings_with_data,
@@ -225,6 +226,8 @@ def main(**kwargs):
     input_folder = Path(settings["input_folder"])
 
     has_scenario_definitions = bool(settings.get("scenario_definitions_fn"))
+    planning_periods = _extract_planning_periods(settings.to_dict())
+    model_years = [period[1] for period in planning_periods]
 
     if has_scenario_definitions:
         scenario_definitions = pd.read_csv(
@@ -242,23 +245,16 @@ def main(**kwargs):
                 scenario_definitions["case_id"].isin(args.case_id), :
             ]
 
-        model_years_for_check = settings["model_year"]
-        if not isinstance(model_years_for_check, list):
-            model_years_for_check = [model_years_for_check]
-
-        if set(scenario_definitions["year"]) != set(model_years_for_check):
+        if set(scenario_definitions["year"]) != set(model_years):
             logger.warning(
                 f"The years included in the scenario definitions file ({set(scenario_definitions['year'])}) "
-                f"do not match the settings parameter `model_year` ({settings['model_year']})"
+                f"do not match the configured model planning years ({set(model_years)})"
             )
     else:
         logger.info(
             "No 'scenario_definitions_fn' found in settings. Resolving settings "
-            "for each planning year from 'model_year' settings parameter."
+            "for each planning year from the configured model planning years."
         )
-        model_years = settings["model_year"]
-        if not isinstance(model_years, list):
-            model_years = [model_years]
         if args.case_id:
             logger.warning(
                 "The --case-id flag is ignored when no 'scenario_definitions_fn' is "
@@ -273,17 +269,20 @@ def main(**kwargs):
             year_settings["case_period"] = period
             scenario_settings[year] = {"Inputs": year_settings}
 
-    model_years_raw = settings["model_year"]
-    first_planning_years_raw = settings["model_first_planning_year"]
-    num_model_years = len(model_years_raw) if isinstance(model_years_raw, list) else 1
-    num_first_planning_years = (
-        len(first_planning_years_raw)
-        if isinstance(first_planning_years_raw, list)
-        else 1
-    )
-    assert (
-        num_model_years == num_first_planning_years
-    ), "The number of years in the settings parameter 'model_year' must be the same as 'model_first_planning_year'"
+    if "model_year" in settings and "model_first_planning_year" in settings:
+        model_years_raw = settings["model_year"]
+        first_planning_years_raw = settings["model_first_planning_year"]
+        num_model_years = (
+            len(model_years_raw) if isinstance(model_years_raw, list) else 1
+        )
+        num_first_planning_years = (
+            len(first_planning_years_raw)
+            if isinstance(first_planning_years_raw, list)
+            else 1
+        )
+        assert (
+            num_model_years == num_first_planning_years
+        ), "The number of years in the settings parameter 'model_year' must be the same as 'model_first_planning_year'"
 
     if has_scenario_definitions:
         # Build a dictionary of settings for every planning year and scenario

--- a/powergenome/run_powergenome.py
+++ b/powergenome/run_powergenome.py
@@ -226,7 +226,8 @@ def main(**kwargs):
     input_folder = Path(settings["input_folder"])
 
     has_scenario_definitions = bool(settings.get("scenario_definitions_fn"))
-    planning_periods = _extract_planning_periods(settings.to_dict())
+    settings_dict = settings.to_dict()
+    planning_periods = _extract_planning_periods(settings_dict)
     model_years = [period[1] for period in planning_periods]
 
     if has_scenario_definitions:
@@ -269,9 +270,9 @@ def main(**kwargs):
             year_settings["case_period"] = period
             scenario_settings[year] = {"Inputs": year_settings}
 
-    if "model_year" in settings and "model_first_planning_year" in settings:
-        model_years_raw = settings["model_year"]
-        first_planning_years_raw = settings["model_first_planning_year"]
+    if "model_year" in settings_dict and "model_first_planning_year" in settings_dict:
+        model_years_raw = settings_dict["model_year"]
+        first_planning_years_raw = settings_dict["model_first_planning_year"]
         num_model_years = (
             len(model_years_raw) if isinstance(model_years_raw, list) else 1
         )

--- a/powergenome/settings.py
+++ b/powergenome/settings.py
@@ -651,8 +651,28 @@ def load_settings(path: Union[str, Path]) -> dict:
             "Path is not recognized. Check that your path is valid."
         )
 
-    if settings.get("input_folder"):
-        settings["input_folder"] = path.parent / settings["input_folder"]
+    settings_folder = path if path.is_dir() else path.parent
+
+    data_locations = settings.get("data_location")
+    if data_locations:
+        values = (
+            data_locations if isinstance(data_locations, list) else [data_locations]
+        )
+        resolved = [
+            value if Path(value).is_absolute() else settings_folder / value
+            for value in values
+        ]
+        settings["data_location"] = (
+            resolved if isinstance(data_locations, list) else resolved[0]
+        )
+
+    input_folder = settings.get("input_folder")
+    if input_folder and not isinstance(input_folder, list):
+        settings["input_folder"] = (
+            input_folder
+            if Path(input_folder).is_absolute()
+            else settings_folder / input_folder
+        )
 
     if settings.get("generator_columns"):
         settings["generator_columns"] = add_model_tags_to_gen_columns(

--- a/powergenome/settings.py
+++ b/powergenome/settings.py
@@ -651,7 +651,9 @@ def load_settings(path: Union[str, Path]) -> dict:
             "Path is not recognized. Check that your path is valid."
         )
 
-    settings_folder = path if path.is_dir() else path.parent
+    # Settings directories contain YAML files, while their relative data paths
+    # are rooted at the directory containing the settings folder.
+    settings_folder = path.parent
 
     data_locations = settings.get("data_location")
     if data_locations:

--- a/powergenome/settings.py
+++ b/powergenome/settings.py
@@ -661,7 +661,7 @@ def load_settings(path: Union[str, Path]) -> dict:
             data_locations if isinstance(data_locations, list) else [data_locations]
         )
         resolved = [
-            value if Path(value).is_absolute() else settings_folder / value
+            Path(value) if Path(value).is_absolute() else settings_folder / value
             for value in values
         ]
         settings["data_location"] = (
@@ -670,10 +670,11 @@ def load_settings(path: Union[str, Path]) -> dict:
 
     input_folder = settings.get("input_folder")
     if input_folder and not isinstance(input_folder, list):
+        input_folder_path = Path(input_folder)
         settings["input_folder"] = (
-            input_folder
-            if Path(input_folder).is_absolute()
-            else settings_folder / input_folder
+            input_folder_path
+            if input_folder_path.is_absolute()
+            else settings_folder / input_folder_path
         )
 
     if settings.get("generator_columns"):

--- a/powergenome/validate.py
+++ b/powergenome/validate.py
@@ -288,7 +288,7 @@ def _check_paths_exist(settings: dict) -> List[ValidationResult]:
         val = settings.get(key)
         if val is None:
             continue
-        values = val if isinstance(val, list) else [val]
+        values = val if isinstance(val, (list, tuple)) else [val]
         for value in values:
             if not Path(value).exists():
                 results.append(

--- a/powergenome/validate.py
+++ b/powergenome/validate.py
@@ -288,10 +288,12 @@ def _check_paths_exist(settings: dict) -> List[ValidationResult]:
         val = settings.get(key)
         if val is None:
             continue
-        if not Path(val).exists():
-            results.append(
-                _err("paths", f"Path specified in '{key}' does not exist: {val}")
-            )
+        values = val if isinstance(val, list) else [val]
+        for value in values:
+            if not Path(value).exists():
+                results.append(
+                    _err("paths", f"Path specified in '{key}' does not exist: {value}")
+                )
 
     input_folder = settings.get("input_folder")
     if input_folder:

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -155,6 +155,36 @@ class TestDataManager:
         assert "plant_region" in dm.available_tables
         assert "demand" in dm.available_tables
 
+    def test_initialization_multiple_locations(
+        self, sample_settings_csv, temp_csv_folder, tmp_path
+    ):
+        """Test that tables can be loaded from multiple data locations."""
+        second_folder = tmp_path / "second"
+        second_folder.mkdir()
+        (temp_csv_folder / "load_data.csv").rename(second_folder / "load_data.csv")
+
+        dm = DataManager()
+        dm.initialize(sample_settings_csv, [temp_csv_folder, second_folder])
+
+        assert dm.get_data("generation").shape[0] == 3
+        assert dm.get_data("demand").shape[0] == 4
+
+    def test_duplicate_table_in_multiple_locations_raises(
+        self, sample_settings_csv, temp_csv_folder, tmp_path
+    ):
+        """Test that duplicate table names are rejected."""
+        second_folder = tmp_path / "second"
+        second_folder.mkdir()
+        (second_folder / "generators.csv").write_bytes(
+            (temp_csv_folder / "generators.csv").read_bytes()
+        )
+
+        with pytest.raises(RuntimeError, match="multiple data locations"):
+            DataManager().initialize(
+                {"generation_table": sample_settings_csv["generation_table"]},
+                [temp_csv_folder, second_folder],
+            )
+
     def test_initialization_sqlite_db(self, sample_settings_db, temp_sqlite_db):
         """Test initialization with SQLite database."""
         # Remove CSV-specific table from settings

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1505,6 +1505,28 @@ class TestExpandCapacityReserveValues:
         assert "CapRes_1" in result["regional_tag_values"]["p1"]
         assert result["regional_tag_values"]["p1"]["CapRes_1"]["Tech1"] == 0.9
 
+    def test_paths_resolve_relative_to_settings_folder(self, tmp_path):
+        """Test that data paths resolve relative to a settings file or folder."""
+        settings_folder = tmp_path / "settings"
+        settings_folder.mkdir()
+        settings_file = settings_folder / "data.yml"
+        settings_content = {
+            "model_regions": ["p1"],
+            "data_location": ["data", "shared/data.db"],
+            "input_folder": "inputs",
+        }
+
+        with open(settings_file, "w") as f:
+            yaml.dump(settings_content, f)
+
+        result = load_settings(settings_file)
+
+        assert result["data_location"] == [
+            settings_folder / "data",
+            settings_folder / "shared/data.db",
+        ]
+        assert result["input_folder"] == settings_folder / "inputs"
+
     def test_integration_with_build_scenario_settings(self, tmp_path):
         """Test that expand_capacity_reserve_values works in scenario building."""
         # Create base settings

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1527,6 +1527,25 @@ class TestExpandCapacityReserveValues:
         ]
         assert result["input_folder"] == settings_folder / "inputs"
 
+    def test_paths_resolve_relative_to_parent_of_settings_directory(self, tmp_path):
+        """Test that directory-based settings retain the study-root convention."""
+        settings_folder = tmp_path / "settings"
+        settings_folder.mkdir()
+        settings_file = settings_folder / "data.yml"
+        settings_content = {
+            "model_regions": ["p1"],
+            "data_location": "test_data",
+            "input_folder": "extra_inputs",
+        }
+
+        with open(settings_file, "w") as f:
+            yaml.dump(settings_content, f)
+
+        result = load_settings(settings_folder)
+
+        assert result["data_location"] == tmp_path / "test_data"
+        assert result["input_folder"] == tmp_path / "extra_inputs"
+
     def test_integration_with_build_scenario_settings(self, tmp_path):
         """Test that expand_capacity_reserve_values works in scenario building."""
         # Create base settings

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -305,6 +305,20 @@ class TestCheckPathsExist:
         s = {"data_location": str(tmp_path)}
         assert _errors(_check_paths_exist(s)) == []
 
+    def test_existing_multiple_data_locations(self, tmp_path):
+        locations = [tmp_path / "data_a", tmp_path / "data_b"]
+        for location in locations:
+            location.mkdir()
+
+        assert _errors(_check_paths_exist({"data_location": locations})) == []
+
+    def test_missing_data_location_in_list(self, tmp_path):
+        locations = [tmp_path, tmp_path / "no_such_folder"]
+        results = _check_paths_exist({"data_location": locations})
+
+        assert len(_errors(results)) == 1
+        assert "no_such_folder" in _errors(results)[0].message
+
     def test_missing_data_location(self, tmp_path):
         s = {"data_location": str(tmp_path / "no_such_folder")}
         results = _check_paths_exist(s)


### PR DESCRIPTION
## Summary

PowerGenome data tables may now be distributed across multiple folders and database files, with relative paths resolved from the settings file or directory. `input_folder` is also searched for configured tables, and duplicate table names across locations fail clearly.

## Testing

- `PYTHONPATH=. pytest -q tests/settings_test.py tests/database_test.py` (172 passed)
- `PYTHONPATH=. pytest -q tests/validate_test.py` (121 passed)
- CLI tests were blocked by an existing SciPy/NumPy binary compatibility error in the environment.

Closes #472