### PR TITLE
Gs/fix parallel vre clustering

### DIFF
--- a/powergenome/new_build.py
+++ b/powergenome/new_build.py
@@ -962,22 +962,34 @@ def build_new_resources(
             regional_cost_multipliers,
         )
 
-        df_list = []
-        settings = apply_all_tag_to_regions(settings)
+        # Avoid passing Settings objects to multiprocessing workers because
+        # serialization can fail during unpickling. Use a plain deep-copied dict.
+        parallel_settings = (
+            copy.deepcopy(settings.to_dict())
+            if hasattr(settings, "to_dict")
+            else copy.deepcopy(settings)
+        )
+        parallel_settings = apply_all_tag_to_regions(parallel_settings)
 
-        clustering_jobs = settings.get("clustering_n_jobs", 1)
+        clustering_jobs = parallel_settings.get("clustering_n_jobs", 1)
+        worker_cluster_builder = cluster_builder if clustering_jobs == 1 else None
+        if clustering_jobs > 1 and cluster_builder is not None:
+            logger.debug(
+                "Ignoring provided cluster_builder for parallel renewable clustering; "
+                "workers will initialize their own builder to avoid pickling errors."
+            )
         logger.info(
             f"Adding renewable resource clusters using {clustering_jobs} parallel jobs."
         )
         df_list = Parallel(n_jobs=clustering_jobs)(
             delayed(parallel_region_renewables)(
-                copy.deepcopy(settings),
+                parallel_settings,
                 new_gen_df,
                 regional_cost_multipliers,
                 rev_mult_region_map,
                 rev_mult_tech_map,
                 region,
-                cluster_builder,
+                worker_cluster_builder,
                 cache_results=cache_results,
                 use_cache=use_cache,
             )

--- a/powergenome/settings.py
+++ b/powergenome/settings.py
@@ -376,7 +376,12 @@ class Settings:
         >>> settings.missing_attr  # Returns None, doesn't raise AttributeError
         None
         """
-        return self._data.get(key, None)
+        # During unpickling, _data may not exist yet. Access it via __dict__ to
+        # avoid recursive __getattr__ calls.
+        data = self.__dict__.get("_data")
+        if data is None:
+            raise AttributeError(key)
+        return data.get(key, None)
 
     def __copy__(self):
         """

--- a/tests/new_build_parallel_test.py
+++ b/tests/new_build_parallel_test.py
@@ -1,0 +1,226 @@
+import pandas as pd
+
+from powergenome import new_build
+from powergenome.settings import Settings
+
+
+class _UnpicklableBuilder:
+    def __getstate__(self):
+        raise TypeError("Cannot pickle this object")
+
+
+def _minimal_resource_inputs():
+    resource_costs = pd.DataFrame(
+        {
+            "technology": ["NaturalGas"],
+            "tech_detail": ["CT"],
+            "cost_case": ["Moderate"],
+            "basis_year": [2030],
+            "fixed_o_m_mw": [1.0],
+            "fixed_o_m_mwh": [0.0],
+            "variable_o_m_mwh": [1.0],
+            "capex_mw": [1000.0],
+            "capex_mwh": [0.0],
+            "wacc_real": [0.07],
+        }
+    )
+    resource_hr = pd.DataFrame(
+        {
+            "technology": ["NaturalGas"],
+            "tech_detail": ["CT"],
+            "cost_case": ["Moderate"],
+            "basis_year": [2030],
+            "heat_rate": [7.0],
+        }
+    )
+    return resource_costs, resource_hr
+
+
+def _minimal_settings(clustering_n_jobs):
+    return {
+        "new_resources": [("NaturalGas", "CT", "Moderate", 100)],
+        "model_year": 2030,
+        "model_regions": ["R1", "R2"],
+        "resource_cap_recovery_years": 20,
+        "clustering_n_jobs": clustering_n_jobs,
+    }
+
+
+def test_parallel_clustering_drops_unpicklable_cluster_builder(monkeypatch):
+    captured_cluster_builders = []
+
+    class FakeParallel:
+        def __init__(self, n_jobs):
+            self.n_jobs = n_jobs
+
+        def __call__(self, tasks):
+            outputs = []
+            for func, args, kwargs in tasks:
+                cluster_builder = (
+                    args[6] if len(args) > 6 else kwargs.get("cluster_builder")
+                )
+                captured_cluster_builders.append(cluster_builder)
+                outputs.append(
+                    pd.DataFrame(
+                        {
+                            "technology": ["NaturalGas_CT_Moderate"],
+                            "Fixed_OM_Cost_per_MWyr": [1],
+                            "Fixed_OM_Cost_per_MWhyr": [0],
+                            "Inv_Cost_per_MWyr": [1],
+                            "Inv_Cost_per_MWhyr": [0],
+                            "Var_OM_Cost_per_MWh": [1.0],
+                        }
+                    )
+                )
+            return outputs
+
+    monkeypatch.setattr(new_build, "Parallel", FakeParallel)
+    monkeypatch.setattr(new_build, "apply_all_tag_to_regions", lambda s: s)
+    monkeypatch.setattr(
+        new_build,
+        "get_data",
+        lambda table_name, **kwargs: (
+            pd.DataFrame(
+                {
+                    "region": ["R1"],
+                    "technology": ["NaturalGas"],
+                    "value": [1.0],
+                }
+            )
+            if table_name == "regional_cost_factor"
+            else pd.DataFrame()
+        ),
+    )
+
+    resource_costs, resource_hr = _minimal_resource_inputs()
+    settings = _minimal_settings(clustering_n_jobs=2)
+
+    result = new_build.build_new_resources(
+        resource_costs=resource_costs,
+        resource_hr=resource_hr,
+        settings=settings,
+        cluster_builder=_UnpicklableBuilder(),
+    )
+
+    assert all(cb is None for cb in captured_cluster_builders)
+    assert not result.empty
+
+
+def test_single_job_clustering_keeps_cluster_builder(monkeypatch):
+    captured_cluster_builders = []
+    builder = _UnpicklableBuilder()
+
+    class FakeParallel:
+        def __init__(self, n_jobs):
+            self.n_jobs = n_jobs
+
+        def __call__(self, tasks):
+            outputs = []
+            for func, args, kwargs in tasks:
+                cluster_builder = (
+                    args[6] if len(args) > 6 else kwargs.get("cluster_builder")
+                )
+                captured_cluster_builders.append(cluster_builder)
+                outputs.append(
+                    pd.DataFrame(
+                        {
+                            "technology": ["NaturalGas_CT_Moderate"],
+                            "Fixed_OM_Cost_per_MWyr": [1],
+                            "Fixed_OM_Cost_per_MWhyr": [0],
+                            "Inv_Cost_per_MWyr": [1],
+                            "Inv_Cost_per_MWhyr": [0],
+                            "Var_OM_Cost_per_MWh": [1.0],
+                        }
+                    )
+                )
+            return outputs
+
+    monkeypatch.setattr(new_build, "Parallel", FakeParallel)
+    monkeypatch.setattr(new_build, "apply_all_tag_to_regions", lambda s: s)
+    monkeypatch.setattr(
+        new_build,
+        "get_data",
+        lambda table_name, **kwargs: (
+            pd.DataFrame(
+                {
+                    "region": ["R1"],
+                    "technology": ["NaturalGas"],
+                    "value": [1.0],
+                }
+            )
+            if table_name == "regional_cost_factor"
+            else pd.DataFrame()
+        ),
+    )
+
+    resource_costs, resource_hr = _minimal_resource_inputs()
+    settings = _minimal_settings(clustering_n_jobs=1)
+
+    result = new_build.build_new_resources(
+        resource_costs=resource_costs,
+        resource_hr=resource_hr,
+        settings=settings,
+        cluster_builder=builder,
+    )
+
+    assert all(cb is builder for cb in captured_cluster_builders)
+    assert not result.empty
+
+
+def test_parallel_clustering_passes_plain_dict_settings(monkeypatch):
+    captured_settings = []
+
+    class FakeParallel:
+        def __init__(self, n_jobs):
+            self.n_jobs = n_jobs
+
+        def __call__(self, tasks):
+            outputs = []
+            for func, args, kwargs in tasks:
+                settings_arg = args[0] if len(args) > 0 else kwargs.get("settings")
+                captured_settings.append(settings_arg)
+                outputs.append(
+                    pd.DataFrame(
+                        {
+                            "technology": ["NaturalGas_CT_Moderate"],
+                            "Fixed_OM_Cost_per_MWyr": [1],
+                            "Fixed_OM_Cost_per_MWhyr": [0],
+                            "Inv_Cost_per_MWyr": [1],
+                            "Inv_Cost_per_MWhyr": [0],
+                            "Var_OM_Cost_per_MWh": [1.0],
+                        }
+                    )
+                )
+            return outputs
+
+    monkeypatch.setattr(new_build, "Parallel", FakeParallel)
+    monkeypatch.setattr(new_build, "apply_all_tag_to_regions", lambda s: s)
+    monkeypatch.setattr(
+        new_build,
+        "get_data",
+        lambda table_name, **kwargs: (
+            pd.DataFrame(
+                {
+                    "region": ["R1"],
+                    "technology": ["NaturalGas"],
+                    "value": [1.0],
+                }
+            )
+            if table_name == "regional_cost_factor"
+            else pd.DataFrame()
+        ),
+    )
+
+    resource_costs, resource_hr = _minimal_resource_inputs()
+    settings = Settings(data=_minimal_settings(clustering_n_jobs=2))
+
+    result = new_build.build_new_resources(
+        resource_costs=resource_costs,
+        resource_hr=resource_hr,
+        settings=settings,
+    )
+
+    assert captured_settings
+    assert all(isinstance(s, dict) for s in captured_settings)
+    assert not any(isinstance(s, Settings) for s in captured_settings)
+    assert not result.empty


### PR DESCRIPTION
This pull request addresses issues related to parallelization and object serialization in the `build_new_resources` function, particularly when using multiprocessing for renewable resource clustering. The main focus is to ensure that only serializable objects are passed to worker processes, preventing pickling errors, and to improve robustness in settings handling. Comprehensive tests have been added to verify the new behavior.

**Parallelization and Serialization Improvements:**

* Updated `build_new_resources` in `powergenome/new_build.py` to avoid passing potentially unpicklable objects (such as custom `Settings` instances or user-provided cluster builders) to multiprocessing workers. Instead, a deep-copied plain dictionary of settings is used, and the cluster builder is only passed if running in single-threaded mode.

**Settings Handling Robustness:**

* Improved the `__getattr__` method in `Settings` (`powergenome/settings.py`) to avoid recursive calls and handle missing internal state gracefully during unpickling, raising `AttributeError` if `_data` is not present.

**Testing Enhancements:**

* Added `tests/new_build_parallel_test.py` to verify that:
  - Unpicklable cluster builders are not passed to parallel workers.
  - The cluster builder is preserved in single-threaded execution.
  - Only plain dictionaries (not `Settings` objects) are passed to workers in parallel mode.