### PR TITLE
Support both tidy and wide-format profile files

### DIFF
--- a/powergenome/cluster/renewables.py
+++ b/powergenome/cluster/renewables.py
@@ -20,6 +20,93 @@ from powergenome.util import load_data, snake_case_str
 logger = logging.getLogger(__name__)
 
 
+def _load_wide_or_raise(
+    path: Path,
+    site_ids: List[str],
+    weather_year: Optional[Union[int, List[int]]],
+    columns: List[str],
+    required_cols: set,
+) -> pd.DataFrame:
+    """Handle wide-format or unrecognized profile files.
+
+    If ``weather_year`` is specified but the file is wide format, raise ValueError.
+    If ``weather_year`` is None and the file is wide format (columns match site_ids),
+    warn and load matching columns. Otherwise raise ValueError for unrecognized format.
+
+    Parameters
+    ----------
+    path : Path
+        Path to profiles file.
+    site_ids : List[str]
+        Requested site identifiers.
+    weather_year : Optional[Union[int, List[int]]]
+        Weather year filter.
+    columns : List[str]
+        Column names from the file.
+    required_cols : set
+        Set of required tidy column names.
+
+    Returns
+    -------
+    pd.DataFrame
+        Wide DataFrame with requested site_ids as columns.
+
+    Raises
+    ------
+    ValueError
+        If format is unrecognized or weather_year is specified on wide format.
+    """
+    cols_set = set(columns)
+    site_ids_str = [str(s) for s in site_ids]
+    found = set(site_ids_str) & cols_set
+
+    if not found:
+        raise ValueError(
+            "Profiles file has an unrecognized format. It is neither tidy "
+            f"(missing columns {required_cols}) nor wide "
+            "(no column names match the requested site IDs). "
+            f"Found columns: {columns}, "
+            f"requested site IDs: {site_ids}"
+        )
+
+    if weather_year is not None:
+        raise ValueError(
+            "weather_year filtering requires tidy-format profiles with a "
+            "'weather_year' column. The profiles file appears to be in wide "
+            f"format (columns are site IDs, not {required_cols}). "
+            f"Found columns: {columns}"
+        )
+
+    logger.warning(
+        "Profiles file is in wide format (columns are site IDs) rather than "
+        f"tidy format with columns {required_cols}. "
+        "Wide-format loading is deprecated; please convert to tidy format. "
+        "Loading the full timeseries data into memory."
+    )
+
+    # Read only the requested site columns that exist
+    cols_to_read = [s for s in site_ids_str if s in cols_set]
+    suffix = path.suffix
+    if suffix == ".parquet":
+        df = pq.read_table(path, columns=cols_to_read).to_pandas()
+    elif suffix == ".csv":
+        df = pd.read_csv(path, usecols=cols_to_read)
+    else:
+        raise ValueError(f"Unsupported profile file format: {suffix}")
+
+    # Rename string column names back to original site_id types
+    rename_map = {}
+    for s in site_ids:
+        if str(s) in cols_to_read:
+            rename_map[str(s)] = s
+    df = df.rename(columns=rename_map)
+
+    # Fill missing site_ids with 1.0
+    for m in set(site_ids) - set(df.columns):
+        df[m] = 1.0
+    return df[list(site_ids)]
+
+
 def load_site_profiles(
     path: Path,
     site_ids: List[str],
@@ -87,17 +174,19 @@ def load_site_profiles(
         return wide[site_ids]
 
     if suffix == ".parquet":
-        # Validate tidy format
+        # Read schema to determine format
         try:
             schema_names = pq.read_schema(path).names
         except Exception:
             schema_names = []
         required_cols = {"site_id", "time_index", "value"}
-        if not required_cols.issubset(set(schema_names)):
-            raise ValueError(
-                f"Resource profiles must be in tidy format with columns {required_cols}. "
-                f"Found columns: {schema_names}"
+        is_tidy = required_cols.issubset(set(schema_names))
+
+        if not is_tidy:
+            return _load_wide_or_raise(
+                path, site_ids, weather_year, schema_names, required_cols
             )
+
         # Read minimal columns via duckdb with DNF filters
         cols = ["site_id", "time_index", "value"]
         if "weather_year" in schema_names:
@@ -112,13 +201,13 @@ def load_site_profiles(
         df = load_data(path.parent, path.name, filters=filters, columns=cols)
         return _pivot_tidy(df)
     elif suffix == ".csv":
-        # Validate tidy format
         header = pd.read_csv(path, nrows=0).columns.tolist()
         required_cols = {"site_id", "time_index", "value"}
-        if not required_cols.issubset(set(header)):
-            raise ValueError(
-                f"Resource profiles must be in tidy format with columns {required_cols}. "
-                f"Found columns: {header}"
+        is_tidy = required_cols.issubset(set(header))
+
+        if not is_tidy:
+            return _load_wide_or_raise(
+                path, site_ids, weather_year, header, required_cols
             )
         usecols = [
             c for c in ["site_id", "time_index", "value", "weather_year"] if c in header

--- a/powergenome/resource_clusters.py
+++ b/powergenome/resource_clusters.py
@@ -568,25 +568,36 @@ class ResourceGroup:
         # Get identifiers from metadata
         ids = self.metadata.read(columns=["id"])["id"]
         columns = self.profiles.columns
-        # All profiles must be in tidy format
         required_cols = {"site_id", "time_index", "value"}
         if not required_cols.issubset(set(columns)):
-            raise ValueError(
-                f"Resource profiles must be in tidy format with columns {required_cols}. "
-                f"Found columns: {columns}"
+            # Not tidy format. Check if it might be wide format (site IDs as columns)
+            requested = set(ids.astype(str))
+            found = requested & set(columns)
+            if found:
+                # Wide format: validate profile length using the first matching column
+                first_id = next(iter(found))
+                df = self.profiles.read(columns=[first_id])
+                n_hours = len(df)
+            else:
+                raise ValueError(
+                    "Profiles file has an unrecognized format. It is neither tidy "
+                    f"(missing columns {required_cols}) nor wide "
+                    "(no column names match metadata IDs). "
+                    f"Found columns: {list(columns)}"
+                )
+        else:
+            # Validate profile length for at least one id
+            first_id = ids.iloc[0]
+            df = self.profiles.read(
+                columns=[
+                    c
+                    for c in ["site_id", "time_index", "value", "weather_year"]
+                    if c in columns
+                ]
             )
-        # Validate profile length for at least one id
-        first_id = ids.iloc[0]
-        df = self.profiles.read(
-            columns=[
-                c
-                for c in ["site_id", "time_index", "value", "weather_year"]
-                if c in columns
-            ]
-        )
-        df = df[df["site_id"] == first_id]
-        # Count unique time_index values (could span multiple weather years)
-        n_hours = df["time_index"].nunique()
+            df = df[df["site_id"] == first_id]
+            # Count unique time_index values (could span multiple weather years)
+            n_hours = df["time_index"].nunique()
         # Valid if it's a multiple of 8760 or 8784 (for multi-year data)
         if n_hours % 8760 != 0 and n_hours % 8784 != 0:
             raise ValueError(
@@ -754,13 +765,52 @@ class ResourceGroup:
             loaded, time_index will span all years.
         """
         cols = self.profiles.columns
-        # All profiles must be in tidy format
         required_cols = {"site_id", "time_index", "value"}
-        if not required_cols.issubset(set(cols)):
-            raise ValueError(
-                f"Resource profiles must be in tidy format with columns {required_cols}. "
-                f"Found columns: {list(cols)}"
+        is_tidy = required_cols.issubset(set(cols))
+
+        if not is_tidy:
+            # Wide format: columns are site IDs, rows are time steps.
+            # Verify that at least one requested site_id appears as a column name,
+            # matching as strings since column names are always strings.
+            cols_str = set(str(c) for c in cols)
+            requested_str = set(str(s) for s in site_ids)
+            found = requested_str & cols_str
+            if not found:
+                raise ValueError(
+                    "Profiles file has an unrecognized format. It is neither tidy "
+                    f"(missing columns {required_cols}) nor wide "
+                    "(no column names match the requested site IDs). "
+                    f"Found columns: {list(cols)}, "
+                    f"requested site IDs: {list(requested_str)}"
+                )
+            if weather_year is not None:
+                raise ValueError(
+                    "weather_year filtering requires tidy-format profiles with a "
+                    "'weather_year' column. The profiles file appears to be in wide "
+                    f"format (columns are site IDs, not {required_cols}). "
+                    f"Found columns: {list(cols)}"
+                )
+            logger.warning(
+                "Profiles file is in wide format (columns are site IDs) rather than "
+                f"tidy format with columns {required_cols}. "
+                "Wide-format loading is deprecated; please convert to tidy format. "
+                "Loading the full timeseries data into memory."
             )
+            # Read columns by their string names, only requesting columns that exist
+            site_ids_str = [str(s) for s in site_ids]
+            available_cols = set(str(c) for c in cols)
+            cols_to_read = [s for s in site_ids_str if s in available_cols]
+            wide = self.profiles.read(columns=cols_to_read)
+            # Map string column names back to original site_id types
+            rename_map = {}
+            for s in site_ids:
+                if str(s) in cols_to_read:
+                    rename_map[str(s)] = s
+            wide = wide.rename(columns=rename_map)
+            # Fill missing site_ids with 1.0
+            for m in set(site_ids) - set(wide.columns):
+                wide[m] = 1.0
+            return wide[list(site_ids)]
 
         years = None
         # If profiles are provided in-memory (no path), fall back to Table.read

--- a/tests/renewable_cluster_test.py
+++ b/tests/renewable_cluster_test.py
@@ -1,5 +1,6 @@
 "Test functions for clustering renewable sites"
 
+import logging
 from pathlib import Path
 
 import hypothesis
@@ -551,19 +552,62 @@ def test_load_site_profiles_unsupported_format():
 
 
 def test_load_site_profiles_missing_required_columns_csv(tmp_path):
-    """Test that CSV without required columns raises ValueError."""
+    """Test that CSV without tidy columns and no site_id column matches raises ValueError."""
     bad_csv = tmp_path / "bad_profiles.csv"
     pd.DataFrame({"wrong_col": [1, 2], "another": [3, 4]}).to_csv(bad_csv, index=False)
-    with pytest.raises(ValueError, match="must be in tidy format"):
+    with pytest.raises(ValueError, match="unrecognized format"):
         load_site_profiles(bad_csv, site_ids=[1, 2])
 
 
 def test_load_site_profiles_missing_required_columns_parquet(tmp_path):
-    """Test that parquet without required columns raises ValueError."""
+    """Test that parquet without tidy columns and no site_id column matches raises ValueError."""
     bad_parquet = tmp_path / "bad_profiles.parquet"
     pd.DataFrame({"wrong_col": [1, 2], "another": [3, 4]}).to_parquet(bad_parquet)
-    with pytest.raises(ValueError, match="must be in tidy format"):
+    with pytest.raises(ValueError, match="unrecognized format"):
         load_site_profiles(bad_parquet, site_ids=[1, 2])
+
+
+def test_load_site_profiles_wide_csv(tmp_path, caplog):
+    """Wide CSV without weather_year: warns and loads matching columns."""
+    wide_csv = tmp_path / "wide_profiles.csv"
+    pd.DataFrame({"1": [0.1, 0.2, 0.3], "2": [0.4, 0.5, 0.6]}).to_csv(
+        wide_csv, index=False
+    )
+    site_ids = ["1", "3"]  # "3" is missing
+    with caplog.at_level(logging.WARNING):
+        df = load_site_profiles(wide_csv, site_ids=site_ids)
+    assert "wide format" in caplog.text.lower()
+    assert list(df.columns) == ["1", "3"]
+    assert len(df) == 3
+    assert (df["3"] == 1.0).all()
+
+
+def test_load_site_profiles_wide_parquet(tmp_path, caplog):
+    """Wide parquet without weather_year: warns and loads matching columns."""
+    wide_pq = tmp_path / "wide_profiles.parquet"
+    pd.DataFrame({"1": [0.1, 0.2, 0.3], "2": [0.4, 0.5, 0.6]}).to_parquet(wide_pq)
+    site_ids = ["1", "2"]
+    with caplog.at_level(logging.WARNING):
+        df = load_site_profiles(wide_pq, site_ids=site_ids)
+    assert "wide format" in caplog.text.lower()
+    assert list(df.columns) == ["1", "2"]
+    assert len(df) == 3
+
+
+def test_load_site_profiles_wide_csv_with_weather_year_raises(tmp_path):
+    """Wide CSV with weather_year specified: raises ValueError."""
+    wide_csv = tmp_path / "wide_profiles.csv"
+    pd.DataFrame({"1": [0.1, 0.2], "2": [0.4, 0.5]}).to_csv(wide_csv, index=False)
+    with pytest.raises(ValueError, match="weather_year filtering requires tidy"):
+        load_site_profiles(wide_csv, site_ids=["1"], weather_year=2012)
+
+
+def test_load_site_profiles_wide_parquet_with_weather_year_raises(tmp_path):
+    """Wide parquet with weather_year specified: raises ValueError."""
+    wide_pq = tmp_path / "wide_profiles.parquet"
+    pd.DataFrame({"1": [0.1, 0.2], "2": [0.4, 0.5]}).to_parquet(wide_pq)
+    with pytest.raises(ValueError, match="weather_year filtering requires tidy"):
+        load_site_profiles(wide_pq, site_ids=["1"], weather_year=2012)
 
 
 def test_value_bin_with_bins_outside_data_range(caplog):

--- a/tests/resource_clusters_test.py
+++ b/tests/resource_clusters_test.py
@@ -1,0 +1,297 @@
+"""Tests for resource_clusters.py — ResourceGroup._read_profiles and test_profiles."""
+
+import logging
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from powergenome.resource_clusters import ResourceGroup
+
+
+@pytest.fixture
+def tidy_profiles_df():
+    """Tidy-format profiles: 3 sites × 24 hours."""
+    np.random.seed(42)
+    n_hours = 24
+    site_ids = [0, 1, 2]
+    records = []
+    for sid in site_ids:
+        for t in range(1, n_hours + 1):
+            records.append(
+                {"site_id": sid, "time_index": t, "value": np.random.random()}
+            )
+    return pd.DataFrame(records)
+
+
+@pytest.fixture
+def tidy_profiles_with_weather_df():
+    """Tidy-format profiles with weather_year: 3 sites × 24 hours × 2 years."""
+    np.random.seed(42)
+    n_hours = 24
+    site_ids = [0, 1, 2]
+    weather_years = [2012, 2013]
+    records = []
+    for sid in site_ids:
+        for wy in weather_years:
+            for t in range(1, n_hours + 1):
+                records.append(
+                    {
+                        "site_id": sid,
+                        "time_index": t,
+                        "value": np.random.random(),
+                        "weather_year": wy,
+                    }
+                )
+    return pd.DataFrame(records)
+
+
+@pytest.fixture
+def tidy_profiles_valid_df():
+    """Tidy-format profiles with valid 8760 hours."""
+    np.random.seed(42)
+    n_hours = 8760
+    site_ids = [0, 1]
+    records = []
+    for sid in site_ids:
+        for t in range(1, n_hours + 1):
+            records.append(
+                {"site_id": sid, "time_index": t, "value": np.random.random()}
+            )
+    return pd.DataFrame(records)
+
+
+@pytest.fixture
+def wide_profiles_valid_df():
+    """Wide-format profiles with valid 8760 hours."""
+    np.random.seed(42)
+    n_hours = 8760
+    return pd.DataFrame(
+        {"0": np.random.random(n_hours), "1": np.random.random(n_hours)}
+    )
+
+
+@pytest.fixture
+def wide_profiles_df():
+    """Wide-format profiles: 3 sites as columns × 24 rows."""
+    np.random.seed(42)
+    n_hours = 24
+    return pd.DataFrame(
+        {
+            "0": np.random.random(n_hours),
+            "1": np.random.random(n_hours),
+            "2": np.random.random(n_hours),
+        }
+    )
+
+
+@pytest.fixture
+def unrecognized_profiles_df():
+    """Neither tidy nor wide — completely unrelated columns."""
+    np.random.seed(42)
+    return pd.DataFrame({"foo": range(10), "bar": np.random.random(10)})
+
+
+@pytest.fixture
+def metadata_df():
+    """Minimal metadata for 3 sites."""
+    return pd.DataFrame(
+        {"id": [0, 1, 2], "region": ["A", "A", "B"], "capacity_mw": [100, 200, 150]}
+    )
+
+
+@pytest.fixture
+def metadata_df_2():
+    """Minimal metadata for 2 sites (for valid-length tests)."""
+    return pd.DataFrame({"id": [0, 1], "region": ["A", "A"], "capacity_mw": [100, 200]})
+
+
+@pytest.fixture
+def resource_group_tidy(metadata_df, tidy_profiles_df):
+    """ResourceGroup with tidy-format profiles in memory."""
+    group = {"technology": "utilitypv"}
+    return ResourceGroup(group, metadata=metadata_df, profiles=tidy_profiles_df)
+
+
+@pytest.fixture
+def resource_group_tidy_weather(metadata_df, tidy_profiles_with_weather_df):
+    """ResourceGroup with tidy + weather_year profiles in memory."""
+    group = {"technology": "utilitypv"}
+    return ResourceGroup(
+        group, metadata=metadata_df, profiles=tidy_profiles_with_weather_df
+    )
+
+
+@pytest.fixture
+def resource_group_wide(metadata_df, wide_profiles_df):
+    """ResourceGroup with wide-format profiles in memory."""
+    group = {"technology": "utilitypv"}
+    return ResourceGroup(group, metadata=metadata_df, profiles=wide_profiles_df)
+
+
+@pytest.fixture
+def resource_group_unrecognized(metadata_df, unrecognized_profiles_df):
+    """ResourceGroup with unrecognized-format profiles in memory."""
+    group = {"technology": "utilitypv"}
+    return ResourceGroup(group, metadata=metadata_df, profiles=unrecognized_profiles_df)
+
+
+# ── _read_profiles tests ──────────────────────────────────────────────
+
+
+class TestReadProfiles:
+    """Test ResourceGroup._read_profiles in all format/weather_year combinations."""
+
+    def test_tidy_no_weather_year(self, resource_group_tidy):
+        """Tidy format without weather_year: returns wide DataFrame of requested sites."""
+        result = resource_group_tidy._read_profiles(site_ids=[0, 1])
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == [0, 1]
+        assert len(result) == 24  # n_hours
+
+    def test_tidy_with_weather_year_single(self, resource_group_tidy_weather):
+        """Tidy format with weather_year filter: returns only the specified year."""
+        result = resource_group_tidy_weather._read_profiles(
+            site_ids=[0, 1], weather_year=2012
+        )
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == [0, 1]
+        assert len(result) == 24  # only 2012
+
+    def test_tidy_with_weather_year_list(self, resource_group_tidy_weather):
+        """Tidy format with weather_year list: concatenates years."""
+        result = resource_group_tidy_weather._read_profiles(
+            site_ids=[0, 1], weather_year=[2012, 2013]
+        )
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == [0, 1]
+        assert len(result) == 48  # 2 years × 24h each
+
+    def test_tidy_with_weather_year_missing(self, resource_group_tidy_weather):
+        """Tidy format: weather_year not in data raises ValueError."""
+        with pytest.raises(ValueError, match="None of the requested weather years"):
+            resource_group_tidy_weather._read_profiles(site_ids=[0], weather_year=9999)
+
+    def test_tidy_with_weather_year_all_missing(self, resource_group_tidy_weather):
+        """Tidy format: requesting nonexistent weather years raises ValueError."""
+        with pytest.raises(ValueError, match="None of the requested weather years"):
+            resource_group_tidy_weather._read_profiles(
+                site_ids=[0], weather_year=[9999, 8888]
+            )
+
+    def test_tidy_missing_site_ids_filled(self, resource_group_tidy):
+        """Tidy format: missing site IDs are filled with 1.0."""
+        result = resource_group_tidy._read_profiles(site_ids=[0, 99])
+        assert list(result.columns) == [0, 99]
+        assert (result[99] == 1.0).all()
+
+    def test_wide_no_weather_year(self, resource_group_wide, caplog):
+        """Wide format without weather_year: warns and loads requested columns."""
+        with caplog.at_level(logging.WARNING):
+            result = resource_group_wide._read_profiles(site_ids=[0, 1])
+        assert "wide format" in caplog.text.lower()
+        assert list(result.columns) == [0, 1]
+        assert len(result) == 24
+
+    def test_wide_missing_site_ids_filled(self, resource_group_wide, caplog):
+        """Wide format: missing site IDs filled with 1.0."""
+        with caplog.at_level(logging.WARNING):
+            result = resource_group_wide._read_profiles(site_ids=[0, 99])
+        assert list(result.columns) == [0, 99]
+        assert (result[99] == 1.0).all()
+
+    def test_wide_with_weather_year_raises(self, resource_group_wide):
+        """Wide format with weather_year specified: raises ValueError."""
+        with pytest.raises(ValueError, match="weather_year filtering requires tidy"):
+            resource_group_wide._read_profiles(site_ids=[0], weather_year=2012)
+
+    def test_unrecognized_format_raises(self, resource_group_unrecognized):
+        """Neither tidy nor wide (no matching columns): raises ValueError."""
+        with pytest.raises(
+            ValueError, match="Profiles file has an unrecognized format"
+        ):
+            resource_group_unrecognized._read_profiles(site_ids=[0, 1])
+
+    def test_unrecognized_format_with_weather_year_raises(
+        self, resource_group_unrecognized
+    ):
+        """Unrecognized format with weather_year: raises ValueError."""
+        with pytest.raises(
+            ValueError, match="Profiles file has an unrecognized format"
+        ):
+            resource_group_unrecognized._read_profiles(site_ids=[0], weather_year=2012)
+
+    def test_wide_generates_deprecation_warning(self, resource_group_wide, caplog):
+        """Wide format should log a deprecation warning via logger."""
+        with caplog.at_level(logging.WARNING):
+            resource_group_wide._read_profiles(site_ids=[0])
+        assert "wide format" in caplog.text.lower()
+
+    def test_tidy_multiyear_no_weather_year_concatenates(
+        self, resource_group_tidy_weather, caplog
+    ):
+        """Tidy multiyear without explicit weather_year: concatenates all years."""
+        with caplog.at_level(logging.DEBUG):
+            result = resource_group_tidy_weather._read_profiles(site_ids=[0])
+        assert "concatenating all available years" in caplog.text
+        assert len(result) == 48  # 2 years × 24h
+
+
+# ── test_profiles tests ───────────────────────────────────────────────
+
+
+class TestTestProfiles:
+    """Test ResourceGroup.test_profiles validation."""
+
+    def test_tidy_valid_passes(self, metadata_df_2, tidy_profiles_valid_df):
+        """Tidy format with valid length (8760h): no error."""
+        group = {"technology": "utilitypv"}
+        rg = ResourceGroup(
+            group, metadata=metadata_df_2, profiles=tidy_profiles_valid_df
+        )
+        rg.test_profiles()  # should not raise
+
+    def test_wide_valid_passes(self, metadata_df_2, wide_profiles_valid_df):
+        """Wide format with site IDs matching metadata IDs and 8760h: no error."""
+        group = {"technology": "utilitypv"}
+        rg = ResourceGroup(
+            group, metadata=metadata_df_2, profiles=wide_profiles_valid_df
+        )
+        rg.test_profiles()  # should not raise
+
+    def test_unrecognized_format_raises(self, resource_group_unrecognized):
+        """Neither tidy nor wide: raises ValueError."""
+        with pytest.raises(
+            ValueError, match="Profiles file has an unrecognized format"
+        ):
+            resource_group_unrecognized.test_profiles()
+
+    def test_no_profiles_returns_none(self, metadata_df):
+        """No profiles: test_profiles returns None."""
+        group = {"technology": "utilitypv"}
+        rg = ResourceGroup(group, metadata=metadata_df)
+        assert rg.test_profiles() is None
+
+    def test_tidy_bad_length_raises(self, metadata_df):
+        """Tidy format with invalid hour count: raises ValueError."""
+        bad_profiles = pd.DataFrame(
+            {
+                "site_id": [0] * 100,
+                "time_index": range(1, 101),
+                "value": np.random.random(100),
+            }
+        )
+        group = {"technology": "utilitypv"}
+        rg = ResourceGroup(group, metadata=metadata_df, profiles=bad_profiles)
+        with pytest.raises(ValueError, match="not a multiple of 8760 or 8784"):
+            rg.test_profiles()
+
+    def test_wide_bad_length_raises(self, metadata_df):
+        """Wide format with invalid hour count: raises ValueError."""
+        bad_wide = pd.DataFrame(
+            {"0": np.random.random(100), "1": np.random.random(100)}
+        )
+        group = {"technology": "utilitypv"}
+        rg = ResourceGroup(group, metadata=metadata_df, profiles=bad_wide)
+        with pytest.raises(ValueError, match="not a multiple of 8760 or 8784"):
+            rg.test_profiles()


### PR DESCRIPTION
This pull request significantly improves the handling and validation of renewable resource profile input files, allowing for both "tidy" (long) and "wide" (site-IDs-as-columns) formats, with clear error messages and deprecation warnings for wide format usage. It also expands and strengthens the test suite to ensure robust behavior for all supported and unsupported input scenarios.

The most important changes are:

**Profile File Loading and Validation Improvements**
* Added a new `_load_wide_or_raise` helper in `renewables.py` to handle wide-format resource profile files, including validation, warnings, and fallback logic for missing site IDs. This function raises clear errors for unsupported formats and deprecated usage, and fills missing site IDs with default values.
* Refactored `load_site_profiles` and related code to use `_load_wide_or_raise` for CSV and Parquet files that are not tidy-format, providing better error messages and warnings for unsupported or deprecated formats. [[1]](diffhunk://#diff-9826f3f1073149cfdd9a23c77537c3aee97dbe267ffb218b16277fa77aa5771bL90-R189) [[2]](diffhunk://#diff-9826f3f1073149cfdd9a23c77537c3aee97dbe267ffb218b16277fa77aa5771bL115-R210)
* Updated `ResourceGroup._read_profiles` to robustly distinguish between tidy and wide formats, emit deprecation warnings for wide format, and handle missing or extra site IDs gracefully.

**Validation and Error Handling in Profile Testing**
* Improved `ResourceGroup.test_profiles` to support both tidy and wide formats, with enhanced validation and error messages for unrecognized formats or invalid profile lengths.

**Expanded and Strengthened Test Coverage**
* Added comprehensive tests for wide-format and unrecognized profile files in both CSV and Parquet, including cases with/without `weather_year`, missing site IDs, and deprecation warnings.
* Introduced a new test module (`resource_clusters_test.py`) with fixtures and tests covering all combinations of tidy, wide, and invalid formats for both `_read_profiles` and `test_profiles`, ensuring robust validation and correct fallback/warning behavior.

**Minor and Supporting Changes**
* Enabled logging in test modules to capture and assert warning messages.

These changes collectively make the codebase more robust and user-friendly when ingesting renewable resource profile data, and ensure that future changes to input file support will be well tested and clearly communicated to users.…r handling for unrecognized formats