### PR TITLE
Fix CLI planning year fallback

### DIFF
--- a/powergenome/run_powergenome.py
+++ b/powergenome/run_powergenome.py
@@ -236,7 +236,8 @@ def main(**kwargs):
     has_scenario_definitions = bool(settings.get("scenario_definitions_fn"))
     settings_dict = settings.to_dict()
     planning_periods = _extract_planning_periods(settings_dict)
-    model_years = [period[1] for period in planning_periods]
+    if planning_periods:
+        model_years = [period[1] for period in planning_periods]
 
     if has_scenario_definitions:
         scenario_definitions = pd.read_csv(


### PR DESCRIPTION
CLI tests were failing because `main()` overwrote normalized model years with an empty planning-period extraction when mocked or incomplete settings did not provide `to_dict()` data.

This keeps the existing model-year values unless planning periods are successfully extracted, preserving support for both configured planning periods and legacy/scalar settings.

Tests: `python -m pytest tests/cli_test.py -q` (21 passed); `python -m pytest tests/validate_test.py -q` (123 passed).