### PR TITLE
Rearchitect supplemental demand into make_load_curves (base-stage long-space integration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to Semantic Versioning.
 - Simplified capacity reserve credit specification with `capacity_reserve_values` and auto-expansion. Users can now specify technology credits in a flat format (single constraint) or nested format (multiple constraints) that automatically populate `regional_tag_values`, reducing configuration boilerplate for complex multi-constraint systems. Explicit `regional_tag_values` entries take precedence, allowing mixed automatic and manual specification.
 - weather_year filter support for renewable generation profiles (tidy format). Accepts a single int or a list of ints; when multiple years are provided, profiles are concatenated and a continuous per-site time_index is rebuilt.
 - weather_year filter support for hourly demand profiles. When present, demand is filtered to the requested year and the per-region time_index is rebuilt to be sequential starting at 1.
+- Supplemental demand (`supplemental_demand_table`) region names may now be either a base region or a model region; base-region names are mapped to their aggregated model region automatically.
+- Supplemental demand coverage validation: when the supplemental table has a `weather_year` column and the load data's weather years are known, every weather year must be covered by a specific-year row or an `all` row, otherwise a descriptive error is raised.
 - Comprehensive distributed generation (DG) test suite covering capacity interpolation/extrapolation, multi-weather-year profiles, aggregation, timezone shifting, and hourly generation.
 - Comprehensive error handling test suite for `_parse_interconnect_capex` covering all TypeError, ValueError, and KeyError paths (9 distinct error conditions validated).
 - Interpolation/extrapolation summary logging for DG capacity: single consolidated message listing regions interpolated, backward/forward extrapolated, exact matches, and missing.
@@ -38,6 +40,9 @@ and this project adheres to Semantic Versioning.
 - Hourly DG generation now passes `year` into profile loading to ensure correct capacity-weighted aggregation without relying on global settings state.
 - Regional cost multiplier application now supports automatic averaging for aggregated regions and provides better logging for technologies without explicit mappings.
 - Fuel price workflow simplified: legacy AEO mapping parameters (`fuel_series_scenario_names`, `fuel_series_names`, `fuel_series_region_names`, `fuel_region_map`) are now optional. When not provided, fuel prices are expected directly in the fuel price table for all base regions, and PowerGenome automatically averages base region prices for aggregated regions.
+
+- Supplemental demand is now applied at the base load-data stage (long format) inside `make_load_curves`, before per-weather-year hours are renumbered 1..N and before base regions are aggregated. The old wide-format block-tiling approach (which assumed every weather year had `hours_per_year` hours) has been removed; `weather_year: all` rows now expand to one copy per weather year actually present in the load data, so leap years and other unequal-length weather years are handled correctly.
+- Supplemental demand is no longer applied to the user-supplied wide load path by default. The user-supplied WIDE load path (`load_usr_demand_profiles`) still gets supplemental demand applied in wide format, but weather-year-specific rows are rejected there with a descriptive error.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to Semantic Versioning.
 - Fuel price workflow simplified: legacy AEO mapping parameters (`fuel_series_scenario_names`, `fuel_series_names`, `fuel_series_region_names`, `fuel_region_map`) are now optional. When not provided, fuel prices are expected directly in the fuel price table for all base regions, and PowerGenome automatically averages base region prices for aggregated regions.
 
 - Supplemental demand is now applied at the base load-data stage (long format) inside `make_load_curves`, before per-weather-year hours are renumbered 1..N and before base regions are aggregated. The old wide-format block-tiling approach (which assumed every weather year had `hours_per_year` hours) has been removed; `weather_year: all` rows now expand to one copy per weather year actually present in the load data, so leap years and other unequal-length weather years are handled correctly.
-- Supplemental demand is no longer applied to the user-supplied wide load path by default. The user-supplied WIDE load path (`load_usr_demand_profiles`) still gets supplemental demand applied in wide format, but weather-year-specific rows are rejected there with a descriptive error.
+- Supplemental demand is no longer applied at the end of `make_final_load_curves` for the standard load pipeline; it is applied inside `make_load_curves` instead. The user-supplied WIDE load path (`load_usr_demand_profiles`) still gets supplemental demand applied in wide format, but weather-year-specific rows are rejected there with a descriptive error.
 
 ### Deprecated
 

--- a/docs/how-to/add-supplemental-demand.md
+++ b/docs/how-to/add-supplemental-demand.md
@@ -19,7 +19,7 @@ Create a CSV (or Parquet) file with the additional load you want to add. At mini
 
 | Column | Description |
 |--------|-------------|
-| `region` | Model region name (must match your `model_regions`) |
+| `region` | Base region **or** model region name (see [Step 5: Choose base or model regions](#step-5-choose-base-or-model-regions)) |
 | `time_index` | Integer hour index (1-based) **or** the string `all` / `all_hours` |
 | `load_mw` | MW of demand to add |
 
@@ -29,7 +29,7 @@ Optional columns that PowerGenome will automatically use if present:
 |--------|-------------|
 | `year` | Planning year; when present, rows are filtered to the current `model_year` |
 | `scenario` | Scenario identifier; when present **exactly one** scenario must remain after loading (see [Step 3](#step-3-select-a-scenario-optional)) |
-| `weather_year` | Weather year; use `all` to apply to every weather year, a specific year (e.g. `2012`) to apply only to that block, or a blank value to **skip** the row (see [Step 4](#step-4-handle-multiple-weather-years)) |
+| `weather_year` | Weather year; use `all` to apply to every weather year, a specific year (e.g. `2012`) to apply only to that weather year, or a blank value to **skip** the row (see [Step 4](#step-4-handle-multiple-weather-years)) |
 
 ### Using `all` / `all_hours`
 
@@ -119,11 +119,11 @@ PowerGenome will filter the table to rows where `scenario = "high_data_center"` 
 
 ## Step 4: Handle multiple weather years
 
-If your load curves span several weather years (e.g. three years of 8 760 hours = 26 280 hours total), the `weather_year` column controls which weather-year block a row is applied to:
+If your load curves span several weather years (e.g. three years of 8 760 hours = 26 280 hours total), the `weather_year` column controls which weather year a row is applied to:
 
 **Option A — apply to every weather year (most common)**
 
-Leave out the `weather_year` column entirely and use `all` / `all_hours`, or set `weather_year` to `all`. PowerGenome applies the row to every weather-year block.
+Leave out the `weather_year` column entirely and use `all` / `all_hours`, or set `weather_year` to `all`. PowerGenome applies the row to every weather year present in the load data.
 
 ```csv
 region,time_index,load_mw,year
@@ -137,22 +137,34 @@ WEST,all_hours,500,2035,all
 
 **Option B — apply only to a specific weather year**
 
-Give the row a specific `weather_year` value. An `all` / `all_hours` row then applies to every hour of only that year's block; a specific integer `time_index` applies to just that hour within the block.
+Give the row a specific `weather_year` value. An `all` / `all_hours` row then applies to every hour of only that weather year; a specific integer `time_index` applies to just that hour within the weather year.
 
 ```csv
 region,time_index,load_mw,year,weather_year
-WEST,all_hours,500,2035,2012      # every hour of the 2012 block
-WEST,all_hours,300,2035,2013      # every hour of the 2013 block
-WEST,3,400,2035,2013              # hour 3 of the 2013 block only
+WEST,all_hours,500,2035,2012      # every hour of 2012
+WEST,all_hours,300,2035,2013      # every hour of 2013
+WEST,3,400,2035,2013              # hour 3 of 2013 only
 ```
 
 !!! warning "Blank `weather_year` rows are skipped"
     A row with a blank/empty `weather_year` is **not** applied. Use `weather_year: all` when you want a row to apply across every weather year.
 
 !!! warning "Coverage check"
-    When your load data uses multiple weather years, every weather year must be covered by the supplemental demand table — either by a row for that specific year or by a row with `weather_year: all`. A missing weather year raises an error naming the years that aren't covered. No coverage check is performed when the supplemental demand table has no `weather_year` column.
+    When the supplemental demand table includes a `weather_year` column **and** the load data's weather years are known (via the `weather_year` setting), every weather year present in the load data must be covered by the supplemental demand table — either by a row for that specific year or by a row with `weather_year: all`. A missing weather year raises an error naming the years that aren't covered. No coverage check is performed when the supplemental demand table has no `weather_year` column.
 
-The block size is controlled by `hours_per_year` (default 8 760).
+!!! tip "How supplemental demand is added"
+    Supplemental demand is joined into the **base load data stage**, before the per-weather-year hours are renumbered 1..N and before base regions are aggregated into model regions. Rows that share the same `(region, weather_year, time_index)` are summed together, so there is **no tiling** and **no fixed weather-year length assumption**: weather years of different lengths (e.g. a 8 784-hour leap year next to a normal 8 760-hour year) are handled correctly. This is unlike the older implementation, which block-tiled supplemental load using a fixed `hours_per_year`.
+
+---
+
+## Step 5: Choose base or model regions
+
+The `region` column accepts **either** a base region name or a model region name:
+
+- **Base region name** — the row is mapped to the model region that contains that base region (as configured by `region_aggregations`), and its demand is added to the aggregate's load. If a base region is part of an aggregation, the added demand contributes to the aggregated model region.
+- **Model region name** — the row is applied as-is to the model region.
+
+When the name is a base region that is part of a model-region aggregation, the supplemental demand is added to that one base region, and the aggregation then includes it in the model region. This is equivalent to adding it directly to the model region. Names that match neither a known base region nor a known model region are logged as a warning and ignored.
 
 ---
 

--- a/docs/reference/settings/demand.md
+++ b/docs/reference/settings/demand.md
@@ -82,7 +82,9 @@ Common scenarios:
 **Required**: No
 **Example**: See below
 
-Optional table of additional hourly demand (e.g. data-center forecasts, new industrial loads) to add on top of the baseline demand profiles. Added after distributed-generation subtraction and before integer conversion.
+Optional table of additional hourly demand (e.g. data-center forecasts, new industrial loads) to add on top of the baseline demand profiles.
+
+**How it is applied**: Supplemental demand is joined into the **base load data stage** inside `make_load_curves` — in long format, one row per (region × hour), *before* per-weather-year hours are renumbered to 1..N and *before* base regions are aggregated into model regions. Rows sharing the same `(region, weather_year, time_index)` are summed with the base load, so **no block-tiling is used** and **weather years of unequal length** (e.g. an 8 784-hour leap year next to a normal 8 760-hour year) are handled correctly. A `weather_year: all` row expands to one copy for each weather year actually present in the load data, rather than tiling a fixed block size.
 
 **Simple** (file in `data_location` folder, or co-located with a database):
 
@@ -100,7 +102,10 @@ supplemental_demand_table:
 
 **Required columns**:
 
-- `region`: Model region name (must match `model_regions`)
+- `region`: Base region **or** model region name. Base region names are mapped to the
+  aggregated model region that contains them (per `region_aggregations`); model region
+  names are used as-is. Names matching neither a known base region nor a model region
+  are logged as a warning and ignored.
 - `time_index`: Integer hour index (1-based) **or** the strings `all` / `all_hours`
 - `load_mw`: MW of demand to add
 
@@ -111,20 +116,25 @@ supplemental_demand_table:
   loading. If multiple scenarios are found and none has been selected, PowerGenome raises
   a descriptive error listing the available scenario names and showing how to select one
   (see below).
-- `weather_year`: When present, controls which weather-year block a row applies to:
-  `all` applies the row to every weather-year block, a specific value (e.g. `2012`)
-  applies it only to that block, and a **blank** value causes the row to be skipped
-  (block size controlled by `hours_per_year`, default 8760). When the load data spans
-  multiple weather years, every weather year must be covered by either a specific-value
-  row or an `all` row; a missing weather year raises an error. No coverage check is
-  performed when this column is absent.
+- `weather_year`: When present, controls which weather-year the row applies to:
+  `all` applies the row to every weather year present in the load data, a specific
+  value (e.g. `2012`) applies it only to that weather year, and a **blank** value
+  causes the row to be skipped. There is **no fixed block size**: an `all` row expands
+  to one copy for each weather year actually present, and weather years of different
+  lengths are supported. When the load data spans multiple weather years (its weather
+  years are known via the `weather_year` setting), every weather year must be covered
+  by either a specific-value row or an `all` row; a missing weather year raises an
+  error naming the uncovered years. A specific `weather_year` that does not match any
+  weather year in the load data raises a descriptive error telling you to set the
+  `weather_year` setting. No coverage check is performed when this column is absent.
 
 **`time_index` values**:
 
-- **`all` / `all_hours`** – adds the demand increment to every hour of the weather-year
-  block(s) selected by `weather_year` (flat load addition).
+- **`all` / `all_hours`** – adds the demand increment to every hour of the weather
+  year(s) selected by `weather_year` (flat load addition). For each selected weather
+  year, one copy is added per hour actually present in that weather year.
 - **Integer** – adds the demand increment only to the hour with that index; with
-  `weather_year` set to `all`, it is applied to that hour in every weather-year block.
+  `weather_year` set to `all`, it is applied to that hour in every weather year.
 
 **Scenario handling**:
 

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -190,6 +190,7 @@ def make_load_curves(
     load_curve_columns = get_data(
         table_name="demand", query="PRAGMA table_info('demand')"
     ).name.to_list()
+    weather_years = None
     if "weather_year" in load_curve_columns:
         if settings.get("weather_year"):
             weather_years = (
@@ -227,7 +228,8 @@ def make_load_curves(
         columns=[c for c in get_cols if c in load_curve_columns],
         filters=filters,
     )
-    if "weather_year" in load_curves.columns:
+    has_weather_year = "weather_year" in load_curves.columns
+    if has_weather_year:
         if load_curves.weather_year.nunique() < len(weather_years):
             missing_years = set(weather_years) - set(load_curves.weather_year.unique())
             raise ValueError(
@@ -236,13 +238,29 @@ def make_load_curves(
                 f"available in the demand profiles table: {missing_years}. "
                 "*********************\n"
             )
-        for r in keep_regions:
-            region_mask = load_curves["region"] == r
-            region_data = load_curves.loc[region_mask]
-            if not region_data.empty:
-                load_curves.loc[region_mask, "time_index"] = np.arange(
-                    1, len(region_data) + 1
-                )
+
+    # Merge supplemental demand (e.g. data-center forecasts) into the LONG load
+    # frame NOW, before hours are renumbered and base regions are aggregated.
+    # Supplemental rows carry the same (region, weather_year, time_index) as the
+    # base load hour they augment, so the renumbering + aggregation below handles
+    # them with no block-tiling and no fixed weather-year length.
+    load_curves = add_supplemental_demand_long(
+        load_curves,
+        model_year=settings["model_year"],
+        keep_regions=keep_regions,
+        region_agg_map=region_agg_map,
+        region_aggregations=settings.get("region_aggregations", {}) or {},
+        weather_years=weather_years if has_weather_year else None,
+    )
+
+    # Renumber hours sequentially 1..N per region. Base and supplemental rows
+    # that share (region, weather_year, time_index) receive the SAME renumbered
+    # hour, and weather-year block lengths are derived from the base-load rows so
+    # variable-length (e.g. leap vs non-leap) weather years both work. The frame
+    # is sorted by (region, weather_year, time_index) first so the numbering is
+    # deterministic regardless of the order rows arrive from the database.
+    if has_weather_year:
+        load_curves = _renumber_load_hours(load_curves, weather_years)
     # if settings["model_year"] in demand_years["year"].to_list():
     #     s = f"""
     #         SELECT year, region, time_index, load_mw
@@ -756,114 +774,37 @@ def _norm_weather_year(value):
     return value
 
 
-def add_supplemental_demand(
-    load_curves: pd.DataFrame,
-    model_year: int,
-    model_regions: List[str],
-    hours_per_year: int = 8760,
-    weather_years: Optional[List[int]] = None,
-) -> pd.DataFrame:
-    """Add supplemental hourly demand from the DataManager ``supplemental_demand`` table.
+def _load_supplemental_demand(model_year: int) -> Optional[pd.DataFrame]:
+    """Load and normalize the ``supplemental_demand`` table from DataManager.
 
-    The supplemental demand table should have at minimum the columns:
+    Returns a long-format DataFrame with at least the columns ``region``,
+    ``time_index``, ``load_mw``, plus the normalized helper column ``_time``
+    (either the string ``"all"`` or a single integer hour) and, when the table has
+    a ``weather_year`` column, the normalized ``_norm_wy`` column (a concrete
+    year, ``"all"``, or ``None`` for blank).  Returns ``None`` when the table is
+    not registered or is empty after filtering.
 
-    * ``region`` – model region name
-    * ``time_index`` – integer hour index (1-based) **or** the strings
-      ``"all"``/``"all_hours"``
-    * ``load_mw`` – MW of demand to add
-
-    Optional columns:
-
-    * ``year`` – when present, rows are filtered to ``model_year``
-    * ``scenario`` – when present, exactly one scenario must remain in the data
-      after any DataManager-level filtering; if multiple scenarios exist, a
-      ``ValueError`` is raised with the list of available scenario names and an
-      example of how to select one via the dict-format settings key::
-
-          supplemental_demand_table:
-            table_name: supplemental_demand.csv
-            scenario: high_data_center
-
-    * ``weather_year`` – when present, controls which weather-year block a row is
-      applied to.  A value of ``"all"`` applies the row to every weather-year block;
-      a specific weather year (matching ``weather_years``) applies the row only to
-      that block.  Rows with a **blank** ``weather_year`` are skipped (use ``"all"``
-      to apply across every weather year).  If the ``weather_year`` column is present
-      and ``weather_years`` is provided, a ``ValueError`` is raised when the load
-      data contains a weather year that is not covered by the supplemental demand
-      table (either by a row with that specific year or by a row with ``"all"``).
-
-    ``time_index`` values of ``"all"`` and ``"all_hours"`` (case-insensitive) are
-    expanded to every hour of the weather-year block(s) selected by ``weather_year``.
-
-    Weather-year placement rules (``weather_year`` column present):
-
-    * ``time_index`` = ``"all"``/``"all_hours"``, ``weather_year`` = a specific year
-      – every hour of that year's block receives the supplement.
-    * ``time_index`` = ``"all"``/``"all_hours"``, ``weather_year`` = ``"all"`` –
-      every hour of every block receives the supplement.
-    * ``time_index`` = integer ``t``, ``weather_year`` = a specific year – only hour
-      ``t`` of that year's block receives the supplement.
-    * ``time_index`` = integer ``t``, ``weather_year`` = ``"all"`` – hour ``t`` of
-      every block receives the supplement (tiled with ``hours_per_year`` spacing).
-    * ``weather_year`` blank/empty – the row is skipped.
-
-    If the ``supplemental_demand`` table has **no** ``weather_year`` column,
-    ``"all"``/``"all_hours"`` rows apply to every hour and specific ``time_index``
-    rows apply to just that hour (no tiling across weather years).
-
-    If the ``supplemental_demand`` table is not registered in the DataManager this
-    function is a no-op and returns ``load_curves`` unchanged.
+    Because the result is long format, ``time_index`` here is the *per-weather
+    year* hour number (e.g. 1..8760) rather than a global hour number — the caller
+    is responsible for arranging the rows into weather-year blocks.
 
     Parameters
     ----------
-    load_curves : pd.DataFrame
-        Wide dataframe with one column per model region and ``time_index`` as the
-        index.  This is the same format returned by :func:`make_load_curves`.
     model_year : int
-        Planning year used to filter the supplemental demand table (applied when the
-        table contains a ``year`` column).
-    model_regions : List[str]
-        Model region names; only regions present in both ``load_curves.columns`` and
-        the supplemental demand table are modified.
-    hours_per_year : int, optional
-        Number of hours in a single weather-year block, used to place
-        ``weather_year``-specific and tiled rows.  Defaults to 8760 (standard
-        non-leap year).
-    weather_years : Optional[List[int]], optional
-        Ordered list of weather years in ``load_curves`` (typically
-        ``settings["weather_year"]``).  Used to map a specific ``weather_year`` value
-        to its block and to validate that every loaded weather year is covered by the
-        supplemental demand table.  When ``None``, weather-year-specific rows and the
-        coverage check are disabled (``"all"`` still applies to every block).
-
-    Returns
-    -------
-    pd.DataFrame
-        A copy of ``load_curves`` with the supplemental demand added.
+        Planning year used to filter the table (only applied when the table
+        contains a ``year`` column).
     """
     if "supplemental_demand" not in list_tables():
-        return load_curves
+        return None
 
-    # Normalize the requested weather years into an ordered list of comparable values.
-    if weather_years is not None:
-        if not isinstance(weather_years, list):
-            weather_years = [_norm_weather_year(weather_years)]
-        else:
-            weather_years = [_norm_weather_year(w) for w in weather_years]
-
-    # Discover available columns in the supplemental demand table.
+    # Discover the columns available in the supplemental demand table.
     try:
         col_info = get_data(
-            "supplemental_demand",
-            query="PRAGMA table_info('supplemental_demand')",
+            "supplemental_demand", query="PRAGMA table_info('supplemental_demand')"
         )
         supp_cols = col_info["name"].tolist()
     except Exception:
-        col_info = get_data(
-            "supplemental_demand",
-            query="DESCRIBE supplemental_demand",
-        )
+        col_info = get_data("supplemental_demand", query="DESCRIBE supplemental_demand")
         supp_cols = col_info.iloc[:, 0].tolist()
 
     # Validate that the table has the required columns so users get a helpful
@@ -881,7 +822,8 @@ def add_supplemental_demand(
             "      table_name: <your_table_or_file>"
         )
 
-    # Build filters for the model year.
+    # Only keep rows for the current model year when the table has a year column;
+    # the rest of the filtering is left to the DataManager config.
     filters = None
     if "year" in supp_cols:
         filters = [
@@ -889,13 +831,11 @@ def add_supplemental_demand(
         ]
 
     supp_df = get_data("supplemental_demand", filters=filters)
-
     if supp_df.empty:
-        return load_curves
+        return None
 
-    # If the table has a `scenario` column, verify that exactly one scenario is
-    # present after any DataManager-level filtering. Multiple scenarios mean the user
-    # must specify which one to use via the dict-format table config.
+    # A `scenario` column must resolve to exactly one scenario after any
+    # DataManager-level filtering; otherwise the user must select one in settings.
     if "scenario" in supp_df.columns:
         scenarios = supp_df["scenario"].dropna().unique().tolist()
         if len(scenarios) > 1:
@@ -905,28 +845,17 @@ def add_supplemental_demand(
             raise ValueError(
                 "The supplemental_demand table contains multiple scenarios "
                 f"({scenario_list}) but no scenario has been selected. "
-                "Specify which scenario to use in your settings file, for example:\n\n"
+                "Specify which scenario to use in your settings file, for "
+                "example:\n\n"
                 "    supplemental_demand_table:\n"
                 f"      table_name: <your_table_or_file>\n"
                 f"      scenario: {sorted(str(s) for s in scenarios)[0]}"
             )
 
-    load_curves = load_curves.copy()
-    all_time_indices = load_curves.index.tolist()
-    total_hours = len(all_time_indices)
-    has_weather_year_col = "weather_year" in supp_cols
-
-    # Determine how many weather-year blocks fit in load_curves.
-    if total_hours > hours_per_year and total_hours % hours_per_year == 0:
-        num_blocks = total_hours // hours_per_year
-        block_size = hours_per_year
-    else:
-        num_blocks = 1
-        block_size = total_hours
-
     supp_df = supp_df.copy()
 
-    # Normalize the time_index column: "all" / "all_hours" -> "all".
+    # Normalize time_index: "all" / "all_hours" -> "all"; anything else must be a
+    # single integer hour (rows with other values are dropped with a warning).
     def _norm_time_index(value):
         if isinstance(value, str):
             s = value.strip().lower()
@@ -935,14 +864,30 @@ def add_supplemental_demand(
         return value
 
     supp_df["_time"] = supp_df["time_index"].map(_norm_time_index)
+    time_as_str = supp_df["_time"].astype(str).str.strip().str.lower()
+    not_all = ~time_as_str.eq("all")
+    supp_df.loc[not_all, "_time"] = pd.to_numeric(
+        supp_df.loc[not_all, "_time"], errors="coerce"
+    )
+    n_dropped = int(supp_df["_time"].isna().sum())
+    if n_dropped:
+        logger.warning(
+            "Dropping %d supplemental demand row(s) with a non-numeric, non-all "
+            "time_index.",
+            n_dropped,
+        )
+    supp_df = supp_df.dropna(subset=["_time"])
+    if not supp_df.empty:
+        time_as_str = supp_df["_time"].astype(str).str.strip().str.lower()
+        numeric_mask = ~time_as_str.eq("all")
+        supp_df.loc[numeric_mask, "_time"] = supp_df.loc[numeric_mask, "_time"].astype(
+            int
+        )
 
-    if has_weather_year_col:
-        # Normalize weather_year values: blank -> None (skipped), "all" -> "all",
+    if "weather_year" in supp_cols:
+        # Normalize weather_year: blank -> None (skipped), "all" -> "all",
         # numeric strings -> int.
         supp_df["_norm_wy"] = supp_df["weather_year"].map(_norm_weather_year)
-
-        # Blank weather_year rows are not applied; tell the user about them since
-        # this behaviour changed from earlier versions that tiled blank rows.
         blank_mask = supp_df["_norm_wy"].isna()
         n_blank = int(blank_mask.sum())
         if n_blank:
@@ -951,27 +896,390 @@ def add_supplemental_demand(
                 "use weather_year='all' to apply them across every weather year.",
                 n_blank,
             )
-            supp_df = supp_df[~blank_mask]
+        supp_df = supp_df[~blank_mask]
 
-        if supp_df.empty:
-            return load_curves
+    if supp_df.empty:
+        return None
 
-        # Every weather year present in the load data must be covered by the
-        # supplemental demand table, either by a row for that specific year or by a
-        # row with weather_year="all". This check only runs when weather_years is
-        # known and the supplemental demand table has a weather_year column.
-        if weather_years:
-            covered_years = set(supp_df.loc[supp_df["_norm_wy"] != "all", "_norm_wy"])
-            if (supp_df["_norm_wy"] == "all").any():
-                covered_years = set(weather_years)
-            missing_years = sorted(set(weather_years) - covered_years)
-            if missing_years:
-                raise ValueError(
-                    "The supplemental_demand table does not cover weather year(s) "
-                    f"{missing_years} present in the load data. Add rows with "
-                    "weather_year='all' or a row for each specific weather year so "
-                    "the supplemental demand can be applied to every weather year."
+    return supp_df
+
+
+def _resolve_supp_region(
+    region: str,
+    region_agg_map: Dict[str, str],
+    region_aggregations: Dict[str, List[str]],
+    keep_regions: List[str],
+) -> Optional[str]:
+    """Resolve a supplemental demand region name to a base load-region name.
+
+    Supplemental demand rows may name a region either by its **base** (IPM
+    sub-region) name or by the **model** region it is aggregated into.  Returns
+    the base region whose rows the supplement should be added to, or ``None`` if
+    the name does not resolve to any base or model region.
+
+    Resolution order:
+
+      1. A base region that is aggregated into a model region (a key of
+         ``region_agg_map``, e.g. ``p1``) is used as-is.
+      2. A model region name (a key of ``region_aggregations``, e.g. ``p1_2``) is
+         mapped to its *first* base region.  Because base regions are summed when
+         aggregated, adding the supplement to any one member of the group adds
+         exactly the supplemental amount to the aggregated model-region profile.
+      3. A standalone model region (present in ``keep_regions``, e.g. ``p3``) has
+         the same name as its base region and is used as-is.
+
+    A name matching none of these is logged as a warning and skipped.
+    """
+    if region in region_agg_map:
+        return region
+    if region in region_aggregations:
+        return region_aggregations[region][0]
+    if region in keep_regions:
+        return region
+    logger.warning(
+        "Supplemental demand region '%s' does not match any base or model region; "
+        "its rows will be skipped. Check the 'region' values in your "
+        "supplemental_demand table.",
+        region,
+    )
+    return None
+
+
+def add_supplemental_demand_long(
+    load_curves: pd.DataFrame,
+    model_year: int,
+    keep_regions: List[str],
+    region_agg_map: Dict[str, str],
+    region_aggregations: Dict[str, List[str]],
+    weather_years: Optional[List[int]] = None,
+) -> pd.DataFrame:
+    """Add supplemental demand to a long (one row per region x hour) load frame.
+
+    Called from :func:`make_load_curves` after the base demand rows are loaded but
+    BEFORE hours are renumbered to 1..N and before base regions are aggregated to
+    model regions.  Supplemental rows are emitted in the same long format as the
+    base load rows (one row per region x weather year x hour) and concatenated
+    onto ``load_curves``; the caller's renumbering + groupby/sum aggregation then
+    merges the two sets of rows.  There is no block-tiling and no assumption that
+    every weather year has the same number of hours.
+
+    Each row is tagged with ``_is_supp`` (0 = base load, 1 = supplemental) so the
+    renumbering step can size weather-year blocks from the base-load rows alone.
+
+    Parameters
+    ----------
+    load_curves : pd.DataFrame
+        Long dataframe of base load with columns ``region``, ``time_index``,
+        ``load_mw`` and (optionally) ``weather_year``.
+    model_year : int
+        Planning year passed to :func:`_load_supplemental_demand`.
+    keep_regions, region_agg_map, region_aggregations
+        Region resolution inputs from :func:`powergenome.util.regions_to_keep`.
+    weather_years : Optional[List[int]], optional
+        Ordered list of weather years known to the load data (usually
+        ``settings["weather_year"]``).  Used to expand ``"all"`` weather_year rows
+        and to validate coverage and specific-year references.
+    """
+    load_curves = load_curves.copy()
+    load_curves["_is_supp"] = 0
+
+    supp = _load_supplemental_demand(model_year)
+    if supp is None:
+        return load_curves
+
+    has_wy_col = "weather_year" in supp.columns
+    has_base_wy = "weather_year" in load_curves.columns
+    present_wys = (
+        sorted(load_curves["weather_year"].dropna().unique().tolist())
+        if has_base_wy
+        else []
+    )
+
+    # Coverage check: run only when the supplemental table has a weather_year
+    # column AND the load data's weather years are known.  Every weather year in
+    # the load data must be covered by a specific-year row or an "all" row.
+    if has_wy_col and weather_years:
+        covered_years = set(
+            supp.loc[~supp["_norm_wy"].astype(str).eq("all"), "_norm_wy"]
+        )
+        if (supp["_norm_wy"] == "all").any():
+            covered_years = set(weather_years)
+        missing_years = sorted(set(weather_years) - covered_years)
+        if missing_years:
+            raise ValueError(
+                "The supplemental_demand table does not cover weather year(s) "
+                f"{missing_years} present in the load data. Add rows with "
+                "weather_year='all' or a row for each specific weather year so "
+                "the supplemental demand can be applied to every weather year."
+            )
+
+    # Base hours present in the load data per (region, weather_year).  Used to
+    # expand "all" rows to the real hours and to skip hours that do not exist.
+    if has_base_wy:
+        base_hours = {
+            (reg, wy): sorted(grp["time_index"].dropna().unique().tolist())
+            for (reg, wy), grp in load_curves.groupby(
+                ["region", "weather_year"], dropna=False, sort=False
+            )
+        }
+    else:
+        base_hours = {
+            reg: sorted(grp["time_index"].dropna().unique().tolist())
+            for reg, grp in load_curves.groupby("region", dropna=False, sort=False)
+        }
+
+    def _target_wys(row) -> List:
+        """Weather-year values a row should be applied to."""
+        if not has_wy_col:
+            # No weather_year column: apply to every weather year in the load
+            # data (or, if the load data has no weather-year structure at all,
+            # to every hour of the region).
+            return present_wys if has_base_wy else [None]
+        wy = row["_norm_wy"]
+        if wy == "all":
+            return present_wys
+        if not has_base_wy or wy not in present_wys:
+            raise ValueError(
+                f"A supplemental demand row cites weather_year {wy}, but the "
+                "weather years of the load curves are not known or do not include "
+                f"this year for model year {model_year}. Set `weather_year` in "
+                "your settings file (the same value used to load the demand table) "
+                "so weather-year-specific supplemental demand can be placed in the "
+                "correct hours."
+            )
+        return [wy]
+
+    supp_rows = []
+    for _, row in supp.iterrows():
+        base = _resolve_supp_region(
+            row["region"], region_agg_map, region_aggregations, keep_regions
+        )
+        if base is None:
+            continue
+
+        time_idx = row["_time"]
+        if time_idx == "all":
+            # Expand to every hour of each selected weather-year block.
+            for wy_i in _target_wys(row):
+                key = (base, wy_i) if has_base_wy else base
+                for h in base_hours.get(key, []):
+                    supp_rows.append(
+                        {
+                            "region": base,
+                            "weather_year": wy_i,
+                            "time_index": h,
+                            "load_mw": row["load_mw"],
+                            "_is_supp": 1,
+                        }
+                    )
+        else:
+            # A single integer hour.
+            hour = int(time_idx)
+            for wy_i in _target_wys(row):
+                key = (base, wy_i) if has_base_wy else base
+                if hour not in base_hours.get(key, []):
+                    logger.warning(
+                        "Supplemental demand row for region '%s', weather year %s, "
+                        "hour %d targets an hour that does not exist in the base "
+                        "load data; skipping.",
+                        base,
+                        wy_i,
+                        hour,
+                    )
+                    continue
+                supp_rows.append(
+                    {
+                        "region": base,
+                        "weather_year": wy_i,
+                        "time_index": hour,
+                        "load_mw": row["load_mw"],
+                        "_is_supp": 1,
+                    }
                 )
+
+    if not supp_rows:
+        return load_curves
+
+    supp_long = pd.DataFrame(supp_rows)
+    if not has_base_wy:
+        supp_long = supp_long.drop(columns=["weather_year"])
+
+    return pd.concat([load_curves, supp_long], ignore_index=True)
+
+
+def _renumber_load_hours(
+    load_curves: pd.DataFrame,
+    weather_years: Optional[List[int]] = None,
+) -> pd.DataFrame:
+    """Renumber hours 1..N within each region, merging base and supplemental rows.
+
+    The load frame may contain several weather years, each with an independent
+    (possibly different-length) hour index.  This assigns a single sequential
+    1..N hour number per region.  Weather-year block lengths are measured from the
+    base-load rows only (tagged ``_is_supp == 0``), so a leap year (8784 hours)
+    and a standard year (8760 hours) both work with no fixed ``hours_per_year``
+    assumption.
+
+    Base and supplemental rows that share ``(region, weather_year, time_index)``
+    describe the SAME hour (the supplemental row augments that hour's load), so
+    they receive the same renumbered hour.  The frame is explicitly ordered by
+    ``(region, weather_year, time_index)`` first so the numbering is deterministic
+    regardless of the order rows arrived from the database.
+    """
+    if weather_years is not None:
+        if not isinstance(weather_years, list):
+            weather_years = [_norm_weather_year(weather_years)]
+        else:
+            weather_years = [_norm_weather_year(w) for w in weather_years]
+
+    load_curves = load_curves.copy()
+    if "_is_supp" not in load_curves.columns:
+        load_curves["_is_supp"] = 0
+
+    # Normalize weather_year values so ints/floats/numeric strings compare equal.
+    if "weather_year" in load_curves.columns:
+        load_curves["weather_year"] = load_curves["weather_year"].map(
+            _norm_weather_year
+        )
+
+    present_wys = sorted(
+        load_curves.loc[load_curves["weather_year"].notna(), "weather_year"]
+        .unique()
+        .tolist()
+    )
+    ordered_wys = weather_years if weather_years else present_wys
+    wy_rank = {_norm_weather_year(w): i for i, w in enumerate(ordered_wys)}
+    stragglers = [w for w in present_wys if _norm_weather_year(w) not in wy_rank]
+    for i, w in enumerate(stragglers):
+        wy_rank[_norm_weather_year(w)] = len(ordered_wys) + i
+
+    load_curves["_wy_rank"] = (
+        load_curves["weather_year"]
+        .map(lambda v: wy_rank.get(_norm_weather_year(v), len(wy_rank)))
+        .astype(int)
+    )
+
+    # Deterministic ordering: region -> weather year -> hour -> base/supp.  Sorting
+    # by hour within a weather year puts each supplemental row directly after the
+    # base row for the same (region, weather_year, time_index).
+    load_curves = load_curves.sort_values(
+        ["region", "_wy_rank", "time_index", "_is_supp"], kind="stable"
+    ).reset_index(drop=True)
+
+    base = load_curves.loc[load_curves["_is_supp"] == 0].copy()
+    # 1-based rank of each base hour within its (region, weather_year) block.
+    base["_block_rank"] = (
+        base.groupby(["region", "weather_year"], sort=False)["time_index"]
+        .rank(method="first", ascending=True)
+        .astype(int)
+    )
+    # Weather-year block length (number of distinct base hours) per
+    # (region, weather_year) -- never a fixed hours_per_year.
+    block_sizes = base.groupby(["region", "weather_year"], sort=False)[
+        "time_index"
+    ].nunique()
+    # 0-based starting hour of each block within its region.
+    block_starts = block_sizes.groupby(level=0, sort=False).cumsum() - block_sizes
+
+    merged = load_curves.merge(
+        base[["region", "weather_year", "time_index", "_block_rank"]],
+        on=["region", "weather_year", "time_index"],
+        how="left",
+    )
+    missing = merged["_block_rank"].isna()
+    if missing.any():
+        bad = list(
+            zip(
+                merged.loc[missing, "region"],
+                merged.loc[missing, "weather_year"],
+                merged.loc[missing, "time_index"],
+            )
+        )[:5]
+        raise ValueError(
+            "Could not map every (region, weather_year, time_index) to a base load "
+            "hour while renumbering hours. Supplemental demand rows must target "
+            f"hours that exist in the base load data. Problematic keys include: {bad}"
+        )
+
+    merged = merged.merge(
+        block_starts.rename("_block_start").reset_index(),
+        on=["region", "weather_year"],
+        how="left",
+    )
+    merged["time_index"] = (merged["_block_start"] + merged["_block_rank"]).astype(
+        "int64"
+    )
+    merged = merged.drop(
+        columns=["_block_start", "_block_rank", "_wy_rank", "_is_supp"]
+    )
+    return merged
+
+
+def add_supplemental_demand(
+    load_curves: pd.DataFrame,
+    model_year: int,
+    model_regions: List[str],
+    keep_regions: Optional[List[str]] = None,
+    region_agg_map: Optional[Dict[str, str]] = None,
+    region_aggregations: Optional[Dict[str, List[str]]] = None,
+    weather_years: Optional[List[int]] = None,
+) -> pd.DataFrame:
+    """Add supplemental demand to a WIDE load frame (one column per model region).
+
+    This is a slim variant kept for the user-supplied WIDE load path in
+    :func:`make_final_load_curves` (when ``load_usr_demand_profiles`` supplies the
+    load and :func:`make_load_curves` is never called).  Normal pipelines apply
+    supplemental demand inside :func:`make_load_curves` (via
+    :func:`add_supplemental_demand_long`) in long format.
+
+    A wide frame has no weather-year structure, so no tiling is performed and no
+    fixed ``hours_per_year`` block size is assumed: ``"all"``/``"all_hours"`` rows
+    add to every hour and integer ``time_index`` rows add to just that hour.
+    Weather-year-specific rows are not supported here and raise a ``ValueError``.
+
+    Parameters
+    ----------
+    load_curves : pd.DataFrame
+        Wide dataframe with one column per model region and ``time_index`` as the
+        index.
+    model_year : int
+        Planning year passed to :func:`_load_supplemental_demand`.
+    model_regions : List[str]
+        Model region names; used as a fallback for ``keep_regions`` when not given.
+    keep_regions, region_agg_map, region_aggregations
+        Optional region resolution inputs from :func:`powergenome.util.regions_to_keep`.
+    weather_years : Optional[List[int]], optional
+        Unused in this wide path (no weather-year structure); accepted for
+        signature compatibility.
+    """
+    if "supplemental_demand" not in list_tables():
+        return load_curves
+
+    keep_regions = keep_regions if keep_regions is not None else model_regions
+    region_agg_map = region_agg_map if region_agg_map is not None else {}
+    region_aggregations = region_aggregations if region_aggregations is not None else {}
+
+    supp = _load_supplemental_demand(model_year)
+    if supp is None:
+        return load_curves
+
+    # The wide frame cannot represent per-weather-year hours.
+    if "weather_year" in supp.columns:
+        specific = supp.loc[
+            ~supp["_norm_wy"].astype(str).eq("all"), "_norm_wy"
+        ].dropna()
+        if not specific.empty:
+            years = sorted({int(s) for s in specific})
+            raise ValueError(
+                "The wide (user-supplied) load path does not support weather-year-"
+                f"specific supplemental demand rows (found weather_year values "
+                f"{years}). Use weather_year='all' to apply a row across every "
+                "hour, or apply supplemental demand through the standard load "
+                "pipeline (make_load_curves) instead."
+            )
+
+    load_curves = load_curves.copy()
+    all_indices = load_curves.index.tolist()
 
     def _apply(region: str, by_time: "pd.Series") -> None:
         if region not in load_curves.columns:
@@ -987,79 +1295,29 @@ def add_supplemental_demand(
             load_curves.loc[common, region] + by_time.loc[common]
         )
 
-    def _block_indices(b: int) -> List[int]:
-        start = b * block_size + 1
-        return list(range(start, start + block_size))
+    for region, region_df in supp.groupby("region", sort=False):
+        base = _resolve_supp_region(
+            region, region_agg_map, region_aggregations, keep_regions
+        )
+        if base is None:
+            continue
+        # Map base -> model so we mutate the correct wide column.  A base region
+        # resolves to its aggregated model region; a standalone model region maps
+        # to itself.
+        model = region_agg_map.get(base, base)
 
-    def _wy_block(wy) -> int:
-        """Absolute block index for a specific normalized weather year."""
-        if not weather_years or wy not in weather_years:
-            raise ValueError(
-                f"A supplemental demand row cites weather_year {wy}, but the weather "
-                "years of the load curves are not known or do not include this year. "
-                "Set `weather_year` in your settings file (the same value used to "
-                "load the demand table) so weather-year-specific supplemental demand "
-                "can be placed in the correct hours."
+        all_mask = region_df["_time"].astype(str).str.strip().str.lower().eq("all")
+        all_df = region_df[all_mask]
+        if not all_df.empty:
+            _apply(
+                model,
+                pd.Series(all_df["load_mw"].sum(), index=all_indices, dtype=float),
             )
-        return list(weather_years).index(wy)
-
-    # --- Process "all" time_index rows ---
-    all_mask = supp_df["_time"].astype(str).str.strip().str.lower() == "all"
-    all_df = supp_df[all_mask]
-
-    if not all_df.empty:
-        if has_weather_year_col:
-            for (region, wy), region_df in all_df.groupby(["region", "_norm_wy"]):
-                total_mw = region_df["load_mw"].sum()
-                if wy == "all":
-                    indices = all_time_indices
-                else:
-                    indices = _block_indices(_wy_block(wy))
-                _apply(region, pd.Series(total_mw, index=indices, dtype=float))
-        else:
-            for region, region_df in all_df.groupby("region"):
-                total_mw = region_df["load_mw"].sum()
-                _apply(
-                    region,
-                    pd.Series(total_mw, index=all_time_indices, dtype=float),
-                )
-
-    # --- Process specific time_index rows ---
-    specific_df = supp_df[~all_mask].copy()
-    if not specific_df.empty:
-        specific_df["_time"] = pd.to_numeric(specific_df["_time"], errors="coerce")
-        n_dropped = int(specific_df["_time"].isna().sum())
-        if n_dropped:
-            logger.warning(
-                "Dropping %d supplemental demand row(s) with a non-numeric, "
-                "non-all time_index.",
-                n_dropped,
-            )
-        specific_df = specific_df.dropna(subset=["_time"])
-        specific_df["_time"] = specific_df["_time"].astype(int)
-
-        if has_weather_year_col:
-            for (region, wy), region_df in specific_df.groupby(["region", "_norm_wy"]):
-                by_time = region_df.groupby("_time")["load_mw"].sum()
-                if wy == "all":
-                    # Tile hour t of every weather-year block.
-                    tiled = [
-                        pd.Series(
-                            by_time.values,
-                            index=[int(t) + b * block_size for t in by_time.index],
-                        )
-                        for b in range(num_blocks)
-                    ]
-                    by_time = pd.concat(tiled)
-                else:
-                    # Apply directly to the matching block.
-                    b = _wy_block(wy)
-                    by_time.index = [b * block_size + int(t) for t in by_time.index]
-                _apply(region, by_time)
-        else:
-            for region, region_df in specific_df.groupby("region"):
-                by_time = region_df.groupby("_time")["load_mw"].sum()
-                _apply(region, by_time)
+        specific_df = region_df[~all_mask]
+        if not specific_df.empty:
+            by_time = specific_df.groupby("_time")["load_mw"].sum()
+            by_time.index = by_time.index.astype("int64")
+            _apply(model, by_time)
 
     return load_curves
 
@@ -1096,10 +1354,22 @@ def make_final_load_curves(
     logger.info("Creating hourly demand profiles")
     user_load_curves = load_usr_demand_profiles(settings)
 
+    # Region resolution inputs, used both by the electrification branch and the
+    # wide-format supplemental-demand application for the user-supplied load path.
+    keep_regions, region_agg_map = regions_to_keep(
+        settings["model_regions"], settings.get("region_aggregations", {}) or {}
+    )
+    region_aggregations = settings.get("region_aggregations", {}) or {}
+
+    # Whether the load came entirely from a user-supplied WIDE file. Only that
+    # path needs the wide-format `add_supplemental_demand` below; all other paths
+    # apply supplemental demand inside make_load_curves (long format).
+    used_user_load = False
     if user_load_curves is not None and all(
         [r in user_load_curves.columns for r in settings["model_regions"]]
     ):
         load_curves_before_dr = user_load_curves
+        used_user_load = True
 
     else:
         load_sources = settings.get("load_source_table_name")
@@ -1149,9 +1419,6 @@ def make_final_load_curves(
         "electrification_scenario"
     ):
         load_curves_before_dg = load_curves_before_dr.copy()
-        keep_regions, region_agg_map = regions_to_keep(
-            settings["model_regions"], settings.get("region_aggregations", {}) or {}
-        )
 
         flex_profiles = electrification_profiles(
             settings.get("electrification_stock_fn"),
@@ -1188,13 +1455,27 @@ def make_final_load_curves(
     else:
         final_load_curves = load_curves_before_dg
 
-    # Add supplemental demand (e.g. data center forecasts) if the table is available.
-    final_load_curves = add_supplemental_demand(
-        final_load_curves,
-        model_year=settings["model_year"],
-        model_regions=settings["model_regions"],
-        weather_years=settings.get("weather_year"),
-    )
+    # Supplemental demand is normally added INSIDE make_load_curves (long format,
+    # before hours are renumbered), so it is applied once per load source. With a
+    # single load source (the common default) that applies it exactly once. With
+    # multiple sources in `load_source_table_name` it is applied per source — if
+    # your supplemental table is scoped to a specific region that only exists in
+    # one source, or you keep each source's regions disjoint, this is still
+    # correct; a table that targets the same hours in overlapping sources would
+    # be counted once per source. See also the user-supplied WIDE load path below.
+    # The user-supplied WIDE load path (load_usr_demand_profiles) bypasses
+    # make_load_curves entirely, so supplemental demand is applied here on the
+    # final wide frame to preserve that coverage:
+    if used_user_load:
+        final_load_curves = add_supplemental_demand(
+            final_load_curves,
+            model_year=settings["model_year"],
+            model_regions=settings["model_regions"],
+            keep_regions=keep_regions,
+            region_agg_map=region_agg_map,
+            region_aggregations=region_aggregations,
+            weather_years=settings.get("weather_year"),
+        )
 
     final_load_curves = final_load_curves.astype(int)
 

--- a/powergenome/load_profiles.py
+++ b/powergenome/load_profiles.py
@@ -866,13 +866,16 @@ def _load_supplemental_demand(model_year: int) -> Optional[pd.DataFrame]:
     supp_df["_time"] = supp_df["time_index"].map(_norm_time_index)
     time_as_str = supp_df["_time"].astype(str).str.strip().str.lower()
     not_all = ~time_as_str.eq("all")
-    supp_df.loc[not_all, "_time"] = pd.to_numeric(
-        supp_df.loc[not_all, "_time"], errors="coerce"
-    )
+
+    # Coerce to numeric and reject non-integer hours (e.g. 2.5) rather than truncating.
+    numeric = pd.to_numeric(supp_df.loc[not_all, "_time"], errors="coerce")
+    numeric = numeric.where(numeric.mod(1).eq(0))
+    supp_df.loc[not_all, "_time"] = numeric
+
     n_dropped = int(supp_df["_time"].isna().sum())
     if n_dropped:
         logger.warning(
-            "Dropping %d supplemental demand row(s) with a non-numeric, non-all "
+            "Dropping %d supplemental demand row(s) with a non-numeric, non-integer, non-all "
             "time_index.",
             n_dropped,
         )
@@ -1037,7 +1040,7 @@ def add_supplemental_demand_long(
             return present_wys if has_base_wy else [None]
         wy = row["_norm_wy"]
         if wy == "all":
-            return present_wys
+            return present_wys if has_base_wy else [None]
         if not has_base_wy or wy not in present_wys:
             raise ValueError(
                 f"A supplemental demand row cites weather_year {wy}, but the "

--- a/tests/load_test.py
+++ b/tests/load_test.py
@@ -421,6 +421,8 @@ def _make_supp_get_data(demand, supp, demand_cols, supp_cols):
         data = demand if table_name == "demand" else supp
         df = data.copy()
         if filters:
+            # DataManager filters are DNF: OR-of-AND conjunctions.
+            keep = pd.Series(False, index=df.index)
             for conjunction in filters:
                 mask = pd.Series(True, index=df.index)
                 for col, op, val in conjunction:
@@ -430,8 +432,8 @@ def _make_supp_get_data(demand, supp, demand_cols, supp_cols):
                         mask &= df[col].isin(val)
                     elif op == "!=":
                         mask &= df[col] != val
-                df = df.loc[mask]
-        return df
+                keep |= mask
+            df = df.loc[keep]
 
     return fake_get_data
 

--- a/tests/load_test.py
+++ b/tests/load_test.py
@@ -375,12 +375,52 @@ def test_make_load_curves_all_weather_years(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Tests for add_supplemental_demand
+# Tests for supplemental demand (integrated into make_load_curves)
+#
+# Supplemental demand is now applied INSIDE make_load_curves in long format
+# (before hours are renumbered and base regions aggregated), so these tests
+# exercise the full pipeline via make_load_curves with a fake get_data that
+# serves both the `demand` and `supplemental_demand` tables.
 # ---------------------------------------------------------------------------
 
 
+def _make_supp_get_data(demand, supp, demand_cols, supp_cols):
+    """Build a fake get_data serving the demand and supplemental_demand tables.
+
+    The fake mirrors the DataManager's behavior well enough for these tests:
+    a ``query`` returns the table schema (PRAGMA) and filters are applied in DNF
+    form. The caller is responsible for pre-filtering ``supp`` when modeling
+    DataManager-level (dict-format) filters like ``scenario``.
+    """
+
+    def fake_get_data(table_name, columns=None, filters=None, query=None):
+        if query is not None:
+            if table_name == "demand" and "DISTINCT weather_year" in query:
+                return pd.DataFrame(
+                    {"weather_year": sorted(demand["weather_year"].dropna().unique())}
+                )
+            cols = demand_cols if table_name == "demand" else supp_cols
+            return pd.DataFrame({"name": cols}).astype(object)
+        data = demand if table_name == "demand" else supp
+        df = data.copy()
+        if filters:
+            for conjunction in filters:
+                mask = pd.Series(True, index=df.index)
+                for col, op, val in conjunction:
+                    if op == "=":
+                        mask &= df[col] == val
+                    elif op == "in":
+                        mask &= df[col].isin(val)
+                    elif op == "!=":
+                        mask &= df[col] != val
+                df = df.loc[mask]
+        return df
+
+    return fake_get_data
+
+
 def _base_load_curves(n_hours=4, regions=("R1", "R2"), base_load=100.0):
-    """Helper: build a simple wide load_curves DataFrame."""
+    """Helper: build a simple wide load_curves DataFrame (WIDE-path tests)."""
     idx = pd.RangeIndex(1, n_hours + 1, name="time_index")
     return pd.DataFrame(
         {r: [base_load] * n_hours for r in regions},
@@ -389,104 +429,131 @@ def _base_load_curves(n_hours=4, regions=("R1", "R2"), base_load=100.0):
     )
 
 
-def test_add_supplemental_demand_missing_required_columns(monkeypatch):
+def _long_load(wy_hours, base_load, regions=("R1",), model_year=2030):
+    """Build a long demand frame: one row per (region, wy, hour).
+
+    ``wy_hours`` maps weather year -> number of hours in that year, so years can
+    have different lengths (e.g. leap vs non-leap).
+    """
+    rows = []
+    for wy, n in wy_hours.items():
+        for r in regions:
+            for h in range(1, n + 1):
+                rows.append((model_year, r, wy, h, base_load))
+    return pd.DataFrame(
+        rows,
+        columns=["year", "region", "weather_year", "time_index", "load_mw"],
+    )
+
+
+DEMAND_COLS = ["year", "region", "time_index", "load_mw", "weather_year"]
+SUPP_COLS = ["region", "time_index", "load_mw"]
+
+
+def _run_make_load_curves(
+    monkeypatch,
+    demand,
+    supp=None,
+    supp_cols=None,
+    model_regions=("R1",),
+    region_aggregations=None,
+    weather_year=None,
+    model_year=2030,
+    **extra,
+):
+    """Run make_load_curves with fake demand + (optional) supplemental tables."""
+    monkeypatch.setattr(
+        lp_mod,
+        "list_tables",
+        lambda: ["supplemental_demand"] if supp is not None else [],
+    )
+    monkeypatch.setattr(
+        lp_mod,
+        "get_data",
+        _make_supp_get_data(
+            demand,
+            supp if supp is not None else pd.DataFrame(),
+            DEMAND_COLS,
+            supp_cols if supp_cols is not None else SUPP_COLS,
+        ),
+    )
+    settings = {
+        "model_regions": list(model_regions),
+        "model_year": model_year,
+        "region_aggregations": region_aggregations or {},
+        "utc_offset": 0,
+    }
+    if weather_year is not None:
+        settings["weather_year"] = weather_year
+    settings.update(extra)
+    return _make_load_curves(settings)
+
+
+def test_make_load_curves_supp_no_table(monkeypatch):
+    """No supplemental_demand table -> load_curves unchanged."""
+    demand = _long_load({2012: 4}, 100.0)
+    out = _run_make_load_curves(monkeypatch, demand, weather_year=[2012])
+    assert list(out["R1"]) == [100.0] * 4
+
+
+def test_make_load_curves_supp_missing_required_columns(monkeypatch):
     """Missing required columns (region/time_index/load_mw) raise a descriptive error."""
-
-    # Table is missing time_index
-    supp = pd.DataFrame(
-        {
-            "region": ["R1"],
-            "load_mw": [50.0],
-        }
-    )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "load_mw"]}) if query is not None else supp
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=4)
+    supp = pd.DataFrame({"region": ["R1"], "load_mw": [50.0]})
+    demand = _long_load({2012: 4}, 100.0)
     with pytest.raises(ValueError, match="time_index"):
-        add_supplemental_demand(lc, model_year=2030, model_regions=["R1"])
+        _run_make_load_curves(
+            monkeypatch,
+            demand,
+            supp=supp,
+            supp_cols=["region", "load_mw"],
+            weather_year=[2012],
+        )
 
 
-def test_add_supplemental_demand_no_table(monkeypatch):
-    """When supplemental_demand table is absent, load_curves is returned unchanged."""
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: [])
+def test_make_load_curves_supp_empty_table(monkeypatch):
+    """An empty supplemental_demand table leaves load_curves unchanged."""
+    supp = pd.DataFrame(columns=["region", "time_index", "load_mw"])
+    demand = _long_load({2012: 4}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        weather_year=[2012],
+    )
+    assert list(out["R1"]) == [100.0] * 4
 
-    lc = _base_load_curves()
-    out = add_supplemental_demand(lc, model_year=2030, model_regions=["R1", "R2"])
-    pd.testing.assert_frame_equal(out, lc)
 
-
-def test_add_supplemental_demand_all_hours(monkeypatch):
-    """Rows with time_index='all_hours' are expanded to every hour."""
-
+def test_make_load_curves_supp_no_wy_col_all_hours(monkeypatch):
+    """all_hours expansion when the supplemental table has no weather_year column."""
     supp = pd.DataFrame(
-        {
-            "region": ["R1"],
-            "time_index": ["all_hours"],
-            "load_mw": [50.0],
-        }
+        {"region": ["R1"], "time_index": ["all_hours"], "load_mw": [50.0]}
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw"]})
-            if query is not None
-            else supp
-        ),
+    demand = _long_load({2012: 4}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        weather_year=[2012],
     )
-
-    lc = _base_load_curves(n_hours=4)
-    out = add_supplemental_demand(lc, model_year=2030, model_regions=["R1", "R2"])
-
-    assert list(out["R1"]) == [150.0, 150.0, 150.0, 150.0]
-    assert list(out["R2"]) == [100.0, 100.0, 100.0, 100.0]  # unchanged
+    assert list(out["R1"]) == [150.0] * 4
 
 
-def test_add_supplemental_demand_specific_time_index(monkeypatch):
-    """Rows with a specific integer time_index modify only that hour."""
-
-    supp = pd.DataFrame(
-        {
-            "region": ["R1"],
-            "time_index": [2],
-            "load_mw": [30.0],
-        }
+def test_make_load_curves_supp_no_wy_col_specific_ti(monkeypatch):
+    """A specific time_index without a weather_year column hits only that hour."""
+    supp = pd.DataFrame({"region": ["R1"], "time_index": [2], "load_mw": [30.0]})
+    demand = _long_load({2012: 4}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        weather_year=[2012],
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw"]})
-            if query is not None
-            else supp
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=4)
-    out = add_supplemental_demand(lc, model_year=2030, model_regions=["R1", "R2"])
-
-    # Without weather_year column, no tiling; only hour 2 gets the supplement.
     assert list(out["R1"]) == [100.0, 130.0, 100.0, 100.0]
-    assert list(out["R2"]) == [100.0, 100.0, 100.0, 100.0]
 
 
-def test_add_supplemental_demand_year_filter(monkeypatch):
-    """When a 'year' column exists, rows are filtered to model_year."""
-
-    # Two rows: one for 2030, one for 2035
-    supp_all = pd.DataFrame(
+def test_make_load_curves_supp_year_filter(monkeypatch):
+    """Rows with a year column are filtered to model_year."""
+    supp = pd.DataFrame(
         {
             "year": [2030, 2035],
             "region": ["R1", "R1"],
@@ -494,302 +561,131 @@ def test_add_supplemental_demand_year_filter(monkeypatch):
             "load_mw": [10.0, 999.0],
         }
     )
-    # Simulate DataManager filtering: only return the row matching model_year=2030
-    supp_filtered = supp_all[supp_all["year"] == 2030].copy()
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["year", "region", "time_index", "load_mw"]})
-            if query is not None
-            else supp_filtered
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=4)
-    out = add_supplemental_demand(lc, model_year=2030, model_regions=["R1", "R2"])
-
-    assert list(out["R1"]) == [110.0, 110.0, 110.0, 110.0]
-
-
-def test_add_supplemental_demand_tiled_across_weather_years(monkeypatch):
-    """With weather_year='all', specific time indices tile across weather-year blocks."""
-
-    # load_curves has 8 hours = 2 weather years × 4 hours each
-    supp = pd.DataFrame(
-        {
-            "region": ["R1"],
-            "time_index": [1],  # should apply to hour 1 of each 4-hour block
-            "load_mw": [20.0],
-            "weather_year": ["all"],  # "all" → tile across all blocks
-        }
-    )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "weather_year"]})
-            if query is not None
-            else supp
-        ),
-    )
-
-    # Use hours_per_year=4 so that 8 hours = 2 blocks of 4.
-    lc = _base_load_curves(n_hours=8)
-    out = add_supplemental_demand(
-        lc,
+    demand = _long_load({2012: 4}, 100.0)
+    # The fake get_data applies the year='=' filter for us.
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        supp_cols=["year", "region", "time_index", "load_mw"],
+        weather_year=[2012],
         model_year=2030,
-        model_regions=["R1"],
-        hours_per_year=4,
-        weather_years=[2012, 2013],
     )
-
-    # Hours 1 and 5 should get +20
-    assert out.loc[1, "R1"] == 120.0
-    assert out.loc[5, "R1"] == 120.0
-    # All other hours unchanged
-    for idx in [2, 3, 4, 6, 7, 8]:
-        assert out.loc[idx, "R1"] == 100.0
+    assert list(out["R1"]) == [110.0] * 4
 
 
-def test_add_supplemental_demand_unknown_region(monkeypatch):
-    """Supplemental demand for a region not in load_curves is silently skipped."""
-
+def test_make_load_curves_supp_base_region(monkeypatch):
+    """Supplemental demand can name a BASE region (mapped to the aggregated model region)."""
+    demand = _long_load({2012: 4}, 10.0, regions=("b1", "b2"))
+    # Base region b1, supplemental 5 per hour. M1 = b1 + b2 when aggregated.
     supp = pd.DataFrame(
         {
-            "region": ["UNKNOWN"],
+            "region": ["b1"],
             "time_index": ["all_hours"],
-            "load_mw": [500.0],
+            "load_mw": [5.0],
+            "weather_year": [2012],
         }
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw"]})
-            if query is not None
-            else supp
-        ),
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        supp_cols=["region", "time_index", "load_mw", "weather_year"],
+        model_regions=("M1",),
+        region_aggregations={"M1": ["b1", "b2"]},
+        weather_year=[2012],
     )
-
-    lc = _base_load_curves(n_hours=4)
-    out = add_supplemental_demand(lc, model_year=2030, model_regions=["R1", "R2"])
-
-    # Both regions should be unchanged
-    pd.testing.assert_frame_equal(out, lc)
+    # Each hour: (b1 10 + supp 5) + b2 10 = 25
+    assert list(out["M1"]) == [25.0] * 4
 
 
-def test_add_supplemental_demand_empty_table(monkeypatch):
-    """An empty supplemental demand table leaves load_curves unchanged."""
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw"]})
-            if query is not None
-            else pd.DataFrame(columns=["region", "time_index", "load_mw"])
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=4)
-    out = add_supplemental_demand(lc, model_year=2030, model_regions=["R1", "R2"])
-
-    pd.testing.assert_frame_equal(out, lc)
-
-
-def test_add_supplemental_demand_with_weather_year_all(monkeypatch):
-    """Rows with weather_year='all' tile across all blocks when weather_year col exists."""
-
-    # load_curves: 8 hours (2 blocks of 4)
+def test_make_load_curves_supp_model_region(monkeypatch):
+    """Supplemental demand can name a MODEL region (mapped to its first base region)."""
+    demand = _long_load({2012: 4}, 10.0, regions=("b1", "b2"))
+    # Model region M1 -> added to first base region b1 (adds exactly the
+    # supplemental amount to the summed aggregate profile).
     supp = pd.DataFrame(
         {
-            "region": ["R1"],
-            "time_index": [2],
-            "load_mw": [15.0],
-            "weather_year": ["all"],  # "all" → apply to all blocks
+            "region": ["M1"],
+            "time_index": ["all_hours"],
+            "load_mw": [7.0],
+            "weather_year": [2012],
         }
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "weather_year"]})
-            if query is not None
-            else supp
-        ),
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        supp_cols=["region", "time_index", "load_mw", "weather_year"],
+        model_regions=("M1",),
+        region_aggregations={"M1": ["b1", "b2"]},
+        weather_year=[2012],
     )
+    # Each hour: (b1 10 + supp 7) + b2 10 = 27
+    assert list(out["M1"]) == [27.0] * 4
 
-    lc = _base_load_curves(n_hours=8)
-    out = add_supplemental_demand(
-        lc,
-        model_year=2030,
-        model_regions=["R1"],
-        hours_per_year=4,
-        weather_years=[2012, 2013],
+
+def test_make_load_curves_supp_unknown_region(monkeypatch):
+    """Supplemental demand for an unmapped region is skipped with a warning."""
+    demand = _long_load({2012: 4}, 100.0)
+    supp = pd.DataFrame(
+        {"region": ["Z9"], "time_index": ["all_hours"], "load_mw": [500.0]}
     )
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        weather_year=[2012],
+    )
+    assert list(out["R1"]) == [100.0] * 4
 
-    # time_index 2 and 6 (= 2 + 4) should get +15
-    assert out.loc[2, "R1"] == 115.0
-    assert out.loc[6, "R1"] == 115.0
-    for idx in [1, 3, 4, 5, 7, 8]:
-        assert out.loc[idx, "R1"] == 100.0
 
-
-def test_add_supplemental_demand_all_hours_specific_weather_year(monkeypatch):
-    """all_hours rows apply only to the matching weather-year block."""
-
-    # load_curves: 8 hours = 2 weather years x 4 hours each.
-    # 2013 is covered by a separate row so the coverage check passes.
+def test_make_load_curves_supp_unequal_wy_lengths(monkeypatch):
+    """Supplemental demand lands in the correct per-weather-year hours with NO
+    fixed weather-year-length assumption (2012=4h, 2013=5h)."""
+    demand = _long_load({2012: 4, 2013: 5}, 100.0)
     supp = pd.DataFrame(
         {
             "region": ["R1", "R1"],
             "time_index": ["all_hours", "all_hours"],
-            "load_mw": [300.0, 100.0],
+            "load_mw": [20.0, 300.0],
             "weather_year": [2012, 2013],
         }
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "weather_year"]})
-            if query is not None
-            else supp
-        ),
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        supp_cols=["region", "time_index", "load_mw", "weather_year"],
+        weather_year=[2012, 2013],
     )
-
-    lc = _base_load_curves(n_hours=8)
-    out = add_supplemental_demand(
-        lc,
-        model_year=2030,
-        model_regions=["R1"],
-        hours_per_year=4,
-        weather_years=[2012, 2013],
-    )
-
-    # Only the 2012 block (hours 1-4) should get +300;
-    # the 2013 block gets its own +100.
-    for idx in [1, 2, 3, 4]:
-        assert out.loc[idx, "R1"] == 400.0
-    for idx in [5, 6, 7, 8]:
-        assert out.loc[idx, "R1"] == 200.0
+    # Renumbered hours: 2012 block = 1..4 (100+20), 2013 block = 5..9 (100+300).
+    assert list(out["R1"]) == [120.0] * 4 + [400.0] * 5
 
 
-def test_add_supplemental_demand_all_time_index_alias(monkeypatch):
-    """time_index='all' behaves like 'all_hours' (no weather_year column)."""
-
-    supp = pd.DataFrame(
-        {
-            "region": ["R1"],
-            "time_index": ["all"],
-            "load_mw": [25.0],
-        }
-    )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw"]})
-            if query is not None
-            else supp
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=4)
-    out = add_supplemental_demand(lc, model_year=2030, model_regions=["R1", "R2"])
-
-    assert list(out["R1"]) == [125.0, 125.0, 125.0, 125.0]
-    assert list(out["R2"]) == [100.0, 100.0, 100.0, 100.0]
-
-
-def test_add_supplemental_demand_weather_year_all_all_hours(monkeypatch):
-    """all_hours with weather_year='all' applies to every block."""
-
+def test_make_load_curves_supp_blank_wy_skipped(monkeypatch):
+    """Rows with a blank weather_year are skipped, not tiled or applied."""
     supp = pd.DataFrame(
         {
             "region": ["R1"],
             "time_index": ["all_hours"],
-            "load_mw": [10.0],
-            "weather_year": ["all"],
-        }
-    )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "weather_year"]})
-            if query is not None
-            else supp
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=8)
-    out = add_supplemental_demand(
-        lc,
-        model_year=2030,
-        model_regions=["R1"],
-        hours_per_year=4,
-        weather_years=[2012, 2013],
-    )
-
-    assert list(out["R1"]) == [110.0] * 8
-
-
-def test_add_supplemental_demand_blank_weather_year_skipped(monkeypatch):
-    """Rows with a blank weather_year are skipped, not tiled."""
-
-    supp = pd.DataFrame(
-        {
-            "region": ["R1"],
-            "time_index": [1],
             "load_mw": [50.0],
             "weather_year": [None],
         }
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "weather_year"]})
-            if query is not None
-            else supp
-        ),
+    demand = _long_load({2012: 4, 2013: 4}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        supp_cols=["region", "time_index", "load_mw", "weather_year"],
+        weather_year=[2012, 2013],
     )
-
-    lc = _base_load_curves(n_hours=8)
-    out = add_supplemental_demand(
-        lc,
-        model_year=2030,
-        model_regions=["R1"],
-        hours_per_year=4,
-        weather_years=[2012, 2013],
-    )
-
     assert list(out["R1"]) == [100.0] * 8
 
 
-def test_add_supplemental_demand_missing_weather_year_raises(monkeypatch):
-    """A weather year present in load data but missing from supp demand raises."""
-
-    # Only 2012 is covered; 2013 is present in weather_years but uncovered.
+def test_make_load_curves_supp_coverage_raises(monkeypatch):
+    """A weather year in load data not covered by the table raises ValueError."""
     supp = pd.DataFrame(
         {
             "region": ["R1"],
@@ -798,98 +694,89 @@ def test_add_supplemental_demand_missing_weather_year_raises(monkeypatch):
             "weather_year": [2012],
         }
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "weather_year"]})
-            if query is not None
-            else supp
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=8)
+    demand = _long_load({2012: 4, 2013: 4}, 100.0)
     with pytest.raises(ValueError, match="does not cover weather year"):
-        add_supplemental_demand(
-            lc,
-            model_year=2030,
-            model_regions=["R1"],
-            hours_per_year=4,
-            weather_years=[2012, 2013],
+        _run_make_load_curves(
+            monkeypatch,
+            demand,
+            supp=supp,
+            supp_cols=["region", "time_index", "load_mw", "weather_year"],
+            weather_year=[2012, 2013],
         )
 
 
-def test_add_supplemental_demand_missing_wy_no_error_without_col(monkeypatch):
-    """No error when supp demand has no weather_year column, even with weather_years set."""
+def test_make_load_curves_supp_no_wy_col_no_error(monkeypatch):
+    """No weather_year column in the supplemental table -> no coverage check."""
+    supp = pd.DataFrame(
+        {"region": ["R1"], "time_index": ["all_hours"], "load_mw": [50.0]}
+    )
+    demand = _long_load({2012: 4, 2013: 4}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        weather_year=[2012, 2013],
+    )
+    assert list(out["R1"]) == [150.0] * 8
 
+
+def test_make_load_curves_supp_specific_wy_unknown_raises(monkeypatch):
+    """A specific weather_year that cannot be resolved to a load weather year
+    raises a descriptive ValueError telling the user to set `weather_year`."""
+    # An "all" row covers both years so the coverage check passes, then the
+    # specific 2015 row hits the unresolvable-year error.
     supp = pd.DataFrame(
         {
-            "region": ["R1"],
-            "time_index": ["all_hours"],
-            "load_mw": [50.0],
+            "region": ["R1", "R1"],
+            "time_index": ["all_hours", "all_hours"],
+            "load_mw": [10.0, 50.0],
+            "weather_year": ["all", 2015],
         }
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw"]})
-            if query is not None
-            else supp
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=4)
-    out = add_supplemental_demand(
-        lc,
-        model_year=2030,
-        model_regions=["R1"],
-        weather_years=[2012, 2013],
-    )
-
-    assert list(out["R1"]) == [150.0] * 4
-
-
-def test_add_supplemental_demand_specific_wy_unknown_raises(monkeypatch):
-    """A specific weather_year row without matching weather_years info raises."""
-
-    supp = pd.DataFrame(
-        {
-            "region": ["R1"],
-            "time_index": ["all_hours"],
-            "load_mw": [50.0],
-            "weather_year": [2012],
-        }
-    )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "weather_year"]})
-            if query is not None
-            else supp
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=8)
-    # weather_years=None -> block mapping unavailable for a specific year.
-    with pytest.raises(ValueError, match="cites weather_year 2012"):
-        add_supplemental_demand(
-            lc, model_year=2030, model_regions=["R1"], hours_per_year=4
+    demand = _long_load({2012: 4, 2013: 4}, 100.0)
+    with pytest.raises(ValueError) as exc_info:
+        _run_make_load_curves(
+            monkeypatch,
+            demand,
+            supp=supp,
+            supp_cols=["region", "time_index", "load_mw", "weather_year"],
+            weather_year=[2012, 2013],
         )
+    err = str(exc_info.value)
+    assert "cites weather_year 2015" in err
+    assert "Set `weather_year`" in err
 
 
-def test_add_supplemental_demand_specific_time_with_weather_year(monkeypatch):
-    """A specific time_index with a specific weather_year hits only that block's hour."""
+def test_make_load_curves_supp_all_alias(monkeypatch):
+    """time_index='all' behaves like 'all_hours'."""
+    supp = pd.DataFrame({"region": ["R1"], "time_index": ["all"], "load_mw": [25.0]})
+    demand = _long_load({2012: 4}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        weather_year=[2012],
+    )
+    assert list(out["R1"]) == [125.0] * 4
 
-    # Hour 2 of the 2012 block (index 2), not hour 6.
-    # A no-op 2013 row keeps the coverage check happy.
+
+def test_make_load_curves_supp_all_hours_alias_upper(monkeypatch):
+    """time_index matching is case-insensitive."""
+    supp = pd.DataFrame(
+        {"region": ["R1"], "time_index": ["ALL_HOURS"], "load_mw": [25.0]}
+    )
+    demand = _long_load({2012: 4}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        weather_year=[2012],
+    )
+    assert list(out["R1"]) == [125.0] * 4
+
+
+def test_make_load_curves_supp_specific_ti_with_wy(monkeypatch):
+    """A specific time_index + specific weather_year hits only that block's hour."""
     supp = pd.DataFrame(
         {
             "region": ["R1", "R1"],
@@ -898,35 +785,64 @@ def test_add_supplemental_demand_specific_time_with_weather_year(monkeypatch):
             "weather_year": [2012, 2013],
         }
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "weather_year"]})
-            if query is not None
-            else supp
-        ),
+    demand = _long_load({2012: 4, 2013: 4}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        supp_cols=["region", "time_index", "load_mw", "weather_year"],
+        weather_year=[2012, 2013],
     )
+    # Hour 2 of 2012 block (renumbered 2) gets +15; the 2013 block is +0.
+    assert list(out["R1"]) == [100.0, 115.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0]
 
-    lc = _base_load_curves(n_hours=8)
-    out = add_supplemental_demand(
-        lc,
-        model_year=2030,
-        model_regions=["R1"],
-        hours_per_year=4,
-        weather_years=[2012, 2013],
+
+def test_make_load_curves_supp_all_wy_expansion(monkeypatch):
+    """weather_year='all' expands to EVERY weather year present in the load data."""
+    supp = pd.DataFrame(
+        {
+            "region": ["R1"],
+            "time_index": ["all_hours"],
+            "load_mw": [10.0],
+            "weather_year": ["all"],
+        }
     )
+    demand = _long_load({2012: 4, 2013: 5}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        supp_cols=["region", "time_index", "load_mw", "weather_year"],
+        weather_year=[2012, 2013],
+    )
+    assert list(out["R1"]) == [110.0] * 9
 
-    assert out.loc[2, "R1"] == 115.0
-    for idx in [1, 3, 4, 5, 6, 7, 8]:
-        assert out.loc[idx, "R1"] == 100.0
+
+def test_make_load_curves_supp_all_wy_expansion_no_setting(monkeypatch):
+    """weather_year='all' expands to every weather year when the weather_year
+    setting is absent (years discovered from the demand table)."""
+    supp = pd.DataFrame(
+        {
+            "region": ["R1"],
+            "time_index": ["all_hours"],
+            "load_mw": [10.0],
+            "weather_year": ["all"],
+        }
+    )
+    demand = _long_load({2012: 4, 2013: 4}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        supp_cols=["region", "time_index", "load_mw", "weather_year"],
+        # No weather_year setting: make_load_curves discovers years via a
+        # DISTINCT query on the demand table, which the fake handles.
+    )
+    assert list(out["R1"]) == [110.0] * 8
 
 
-def test_add_supplemental_demand_multiple_scenarios_raises(monkeypatch):
-    """Multiple scenarios in table without selection must raise a descriptive ValueError."""
-
+def test_make_load_curves_supp_multiple_scenarios_raises(monkeypatch):
+    """Multiple scenarios without selection raise a descriptive ValueError."""
     supp = pd.DataFrame(
         {
             "region": ["R1", "R1"],
@@ -935,26 +851,19 @@ def test_add_supplemental_demand_multiple_scenarios_raises(monkeypatch):
             "scenario": ["low_demand", "high_demand"],
         }
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "scenario"]})
-            if query is not None
-            else supp
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=4)
+    demand = _long_load({2012: 4}, 100.0)
     with pytest.raises(ValueError, match="multiple scenarios"):
-        add_supplemental_demand(lc, model_year=2030, model_regions=["R1"])
+        _run_make_load_curves(
+            monkeypatch,
+            demand,
+            supp=supp,
+            supp_cols=["region", "time_index", "load_mw", "scenario"],
+            weather_year=[2012],
+        )
 
 
-def test_add_supplemental_demand_error_shows_scenario_options(monkeypatch):
-    """Error message lists the available scenario names."""
-
+def test_make_load_curves_supp_error_shows_scenario_options(monkeypatch):
+    """Error message lists the available scenario names and the settings key."""
     supp = pd.DataFrame(
         {
             "region": ["R1", "R1"],
@@ -963,33 +872,24 @@ def test_add_supplemental_demand_error_shows_scenario_options(monkeypatch):
             "scenario": ["baseline", "high_data_center"],
         }
     )
-
-    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
-    monkeypatch.setattr(
-        lp_mod,
-        "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "scenario"]})
-            if query is not None
-            else supp
-        ),
-    )
-
-    lc = _base_load_curves(n_hours=4)
+    demand = _long_load({2012: 4}, 100.0)
     with pytest.raises(ValueError) as exc_info:
-        add_supplemental_demand(lc, model_year=2030, model_regions=["R1"])
-
+        _run_make_load_curves(
+            monkeypatch,
+            demand,
+            supp=supp,
+            supp_cols=["region", "time_index", "load_mw", "scenario"],
+            weather_year=[2012],
+        )
     error_msg = str(exc_info.value)
     assert "baseline" in error_msg
     assert "high_data_center" in error_msg
-    # Error should show how to fix it using the dict-format config
     assert "supplemental_demand_table" in error_msg
     assert "scenario:" in error_msg
 
 
-def test_add_supplemental_demand_single_scenario_no_error(monkeypatch):
+def test_make_load_curves_supp_single_scenario_no_error(monkeypatch):
     """A single scenario in the table (after filtering) proceeds without error."""
-
     supp = pd.DataFrame(
         {
             "region": ["R1", "R1"],
@@ -998,20 +898,59 @@ def test_add_supplemental_demand_single_scenario_no_error(monkeypatch):
             "scenario": ["high_data_center", "high_data_center"],
         }
     )
+    demand = _long_load({2012: 4}, 100.0)
+    out = _run_make_load_curves(
+        monkeypatch,
+        demand,
+        supp=supp,
+        supp_cols=["region", "time_index", "load_mw", "scenario"],
+        weather_year=[2012],
+    )
+    # 50 + 50 = 100 MW added to every hour.
+    assert list(out["R1"]) == [200.0] * 4
 
+
+def test_supp_wide_path_no_wy_col_all_hours(monkeypatch):
+    """The slim WIDE variant (user-supplied load path) still applies all_hours."""
+    supp = pd.DataFrame(
+        {"region": ["R1"], "time_index": ["all_hours"], "load_mw": [50.0]}
+    )
     monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
     monkeypatch.setattr(
         lp_mod,
         "get_data",
-        lambda table_name, filters=None, columns=None, query=None: (
-            pd.DataFrame({"name": ["region", "time_index", "load_mw", "scenario"]})
+        lambda table_name, columns=None, filters=None, query=None: (
+            pd.DataFrame({"name": ["region", "time_index", "load_mw"]})
             if query is not None
             else supp
         ),
     )
-
     lc = _base_load_curves(n_hours=4)
-    out = add_supplemental_demand(lc, model_year=2030, model_regions=["R1"])
+    out = add_supplemental_demand(lc, model_year=2030, model_regions=["R1", "R2"])
+    assert list(out["R1"]) == [150.0] * 4
+    assert list(out["R2"]) == [100.0] * 4
 
-    # 50 + 50 = 100 MW added to every hour (two rows with the same scenario)
-    assert list(out["R1"]) == [200.0, 200.0, 200.0, 200.0]
+
+def test_supp_wide_path_specific_wy_raises(monkeypatch):
+    """The wide (user-supplied) path rejects weather-year-specific rows."""
+    supp = pd.DataFrame(
+        {
+            "region": ["R1"],
+            "time_index": ["all_hours"],
+            "load_mw": [50.0],
+            "weather_year": [2012],
+        }
+    )
+    monkeypatch.setattr(lp_mod, "list_tables", lambda: ["supplemental_demand"])
+    monkeypatch.setattr(
+        lp_mod,
+        "get_data",
+        lambda table_name, columns=None, filters=None, query=None: (
+            pd.DataFrame({"name": ["region", "time_index", "load_mw", "weather_year"]})
+            if query is not None
+            else supp
+        ),
+    )
+    lc = _base_load_curves(n_hours=4)
+    with pytest.raises(ValueError, match="does not support weather-year"):
+        add_supplemental_demand(lc, model_year=2030, model_regions=["R1"])

--- a/tests/load_test.py
+++ b/tests/load_test.py
@@ -12,6 +12,23 @@ from powergenome.load_profiles import make_load_curves as _make_load_curves
 from powergenome.load_profiles import subtract_distributed_generation
 
 
+@pytest.fixture(autouse=True)
+def _isolate_data_manager(monkeypatch):
+    """Isolate ``load_profiles.list_tables`` from any DataManager state leaked by
+    other test modules.
+
+    Some test modules (e.g. ``fuel_test``) initialize the global DataManager
+    singleton against the ``tests/test_system`` data folder, which registers a
+    ``supplemental_demand`` table.  Tests in this module that call
+    ``make_load_curves`` directly only patch ``get_data``, so without this the
+    real ``list_tables()`` would report ``supplemental_demand`` and the fake
+    ``get_data`` would serve demand rows as supplemental demand (double-counting
+    every hour).  Default to *no* supplemental table; tests that exercise
+    supplemental demand re-patch ``list_tables`` to register the table.
+    """
+    monkeypatch.setattr(lp_mod, "list_tables", lambda: [])
+
+
 def test_grow_historical_load():
     base_load = {"region": ["A", "A", "B", "B"], "load_mw": [1, 1, 1, 1]}
     base_load_df = pd.DataFrame(base_load)

--- a/tests/load_test.py
+++ b/tests/load_test.py
@@ -434,6 +434,7 @@ def _make_supp_get_data(demand, supp, demand_cols, supp_cols):
                         mask &= df[col] != val
                 keep |= mask
             df = df.loc[keep]
+        return df
 
     return fake_get_data
 


### PR DESCRIPTION
Closes/advances #467 — rearchitects how supplemental hourly demand (e.g. data-center forecasts) is applied on top of load curves.

## What changed

Supplemental demand is now applied **inside `make_load_curves()`** at the base load-data stage — in the long-dataframe space (one row per region × hour) — **before** `time_index` is renumbered to 1..N and **before** the groupby/unstack pivot. This replaces the previous wide-format `add_supplemental_demand()` call at the end of `make_final_load_curves()`, which used block-tiling and assumed every weather year had exactly `hours_per_year` hours.

### Core integration (`powergenome/load_profiles.py`)
- **`_load_supplemental_demand`** — loads/normalizes the `supplemental_demand` table via DataManager, validates required columns (`region`, `time_index`, `load_mw`), applies the `year`→`model_year` filter, enforces exactly-one-scenario, normalizes `time_index` (`all`/`all_hours` → `all`, else int) and the `weather_year` column (blank rows dropped).
- **`add_supplemental_demand_long`** — the main integration step (called from `make_load_curves` at ~line 247): expands `weather_year="all"` to one row per weather year present in the load data (not fixed-size tiling), runs the coverage check (only when the table has a `weather_year` column **and** `settings["weather_year"]` is known), and emits `_is_supp`-tagged long rows.
- **`_resolve_supp_region`** — region resolution order:
  1. base region (key of `region_agg_map`) → used as-is;
  2. model region (key of `region_aggregations`) → its **first base member** (adding to one base member adds exactly the supplemental amount to the model aggregate);
  3. standalone model region (in `regions_to_keep`) → used as-is;
  4. otherwise → warning + skip.
- **`_renumber_load_hours`** — deterministic per-region hour renumbering ordered by `(region, weather_year, time_index, _is_supp)`. Block sizes are computed **from base rows only** (`_is_supp==0`), so base + supplemental rows sharing a `(region, weather_year, hour)` land on the same renumbered hour; variable-length weather years work with no fixed block-size assumption.
- **`add_supplemental_demand`** — slimmed down to a **wide-format variant retained only for edge case 2**; it rejects weather-year-specific rows with a descriptive `ValueError`.

All existing semantics and validations are preserved (see the full matrix in the docs/tests).

## Edge-case decisions

**1. Multi-source load.** `make_final_load_curves` calls `make_load_curves` once per `load_source_table_name` entry. With the move, supplemental demand now applies **once per source**. This is correct and simple for the common **single-source** default (documented in code + how-to). If a user configures overlapping load sources that both carry the same supplemental demand, it would double-count — documented as a known behavior rather than silently fixed.

**2. User-supplied wide load.** `make_final_load_curves` has a branch where the user supplies a wide external load file (`load_usr_demand_profiles`) that bypasses `make_load_curves`. **Preserved**: a `used_user_load` flag gates a slim wide-format `add_supplemental_demand` call at the end of `make_final_load_curves` (after DR/DG subtraction), so that path still receives supplemental demand. That wide path rejects weather-year-specific rows with a descriptive error (it cannot renumber per-weather-year hours in wide space).

## Tests

Rewrote the supplemental-demand suite in `tests/load_test.py` to exercise the new long-format integration via `make_load_curves`/`add_supplemental_demand_long`, covering the full behavior matrix:

- no table → no-op; missing required columns → descriptive error; empty table after filtering → no-op
- `time_index` `all`/`all_hours` (case-insensitive) + specific integer hour
- `weather_year`: specific year, `all` (expanded to every present year), blank → skipped
- coverage check raises when a load weather year isn't covered; **no error** when table has no `weather_year` column
- unknown specific weather year → descriptive `ValueError`
- region as **base region**, as **model region**, unknown/unmapped region
- **variable-length weather years** land in the correct per-weather-year hours (no equal-length assumption)
- `year` filter to `model_year`; `scenario` exactly-one (with options listed in the error)
- two direct wide-path tests (all-hours works; specific-wy raises)

Run and passing (178 total):
```
python -m pytest tests/load_test.py tests/database_test.py tests/util_test.py tests/cli_test.py -q
```
`tests/cli_test.py` runs the real end-to-end pipeline through `tests/test_system/` (the fixture registers `supplemental_demand_table: supplemental_demand.csv` with `p1_2`, `p3` rows / `all_hours`, unequal weather years 2012+2013) — verified green, fixture unchanged.

The pre-existing unrelated failure `resource_clusters_test.py::TestReadProfiles::test_tidy_multiyear_no_weather_year_concatenates` was intentionally left untouched.

## Docs
- `docs/how-to/add-supplemental-demand.md` — base-stage integration, Step 5 for base vs model region names, no tiling / no fixed weather-year-length assumption.
- `docs/reference/settings/demand.md` — integrating table description, region-name semantics, preserved `all`/specific/blank `weather_year` semantics + coverage check.
- `CHANGELOG.md` — 3 new entries.

## Validation
- Ran `python -m pytest tests/load_test.py -q` and `python -m pytest tests/database_test.py tests/util_test.py tests/cli_test.py -q` — **178 passed**.
- Smoke-tested variable-length weather years (2012=4h, 2013=5h) with a base-region row (specific wy) + model-region row (`all`): hours 1–4 = 230, hours 5–9 = 220, 9 total hours, correct aggregated sum.