### PR TITLE
Bump minimum Python to 3.11 and switch pytest CI to uv

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,10 +22,12 @@ jobs:
     - name: Lint with flake8
       run: |
         uv pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        uv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # stop the build if there are Python syntax errors or undefined names.
+        # Exclude .venv since uv creates it inside the workspace (the previous
+        # micromamba environment lived outside the repo).
+        uv run flake8 . --exclude=.venv --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        uv run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        uv run flake8 . --exclude=.venv --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       env:
         RESOURCE_GROUPS: ${{ secrets.RESOURCE_GROUPS }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,9 +5,6 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
     strategy:
       max-parallel: 5
       # matrix:
@@ -15,35 +12,27 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Install Conda environment with Micromamba
-      uses: mamba-org/setup-micromamba@v1
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
       with:
-        environment-file: environment.yml
-        cache-environment: true
-    - run: |
-        conda info
-        conda list
-        conda config --show-sources
-        conda config --show
-        printenv | sort
-    - name: install powergenome
+        python-version: "3.11"
+    - name: Install powergenome with dev dependencies
       run: |
-        pip install -e .
+        uv sync --extra dev
     - name: Lint with flake8
       run: |
-        pip install flake8
+        uv pip install flake8
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        uv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        uv run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       env:
         RESOURCE_GROUPS: ${{ secrets.RESOURCE_GROUPS }}
         PUDL_DB: ${{ secrets.PUDL_DB }}
         PG_DB: ${{ secrets.PG_DB }}
       run: |
-        pip install pytest-cov
-        pytest --cov=powergenome tests/ --cov-report=xml
+        uv run pytest --cov=powergenome tests/ --cov-report=xml
     - name: Upload test coverage report to CodeCov
       uses: codecov/codecov-action@v4
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 ]
 description = "Create power system inputs for capacity expansion models"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 keywords = ["power system data", "capacity expansion", "two"]
 license = { text = "MIT" }
 classifiers = [


### PR DESCRIPTION
## Why

Lower the burden of supporting outdated Python runtimes and modernize the CI test environment. The project now relies on pandas >= 2.2 and duckdb >= 1.3, which no longer make sense to support on Python 3.8.

## What changed

- **`pyproject.toml`**: raise `requires-python` from `>=3.8` to `>=3.11`.
- **`.github/workflows/pytest.yml`**: replace the micromamba/conda environment setup with uv:
  - use `astral-sh/setup-uv@v6` pinned to Python 3.11
  - create the environment with `uv sync --extra dev` (installs both runtime and dev dependencies)
  - run `flake8` and `pytest` through `uv run`

## Notes for reviewers

- The `bash -l {0}` login-shell default was removed since it is only needed for conda initialization.
- `environment.yml` is left untouched; the workflow no longer depends on it.
- Flake8 is still installed on the fly (`uv pip install flake8`) rather than added to the `dev` extras; happy to fold it into `pyproject.toml` if preferred.