### PR TITLE
Allow RESOURCE_GROUPS and RESOURCE_GROUP_PROFILES to accept multiple paths

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,7 +30,6 @@ jobs:
         uv run flake8 . --exclude=.venv --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       env:
-        RESOURCE_GROUPS: ${{ secrets.RESOURCE_GROUPS }}
         PUDL_DB: ${{ secrets.PUDL_DB }}
         PG_DB: ${{ secrets.PG_DB }}
       run: |

--- a/docs/how-to/configure-settings.md
+++ b/docs/how-to/configure-settings.md
@@ -237,6 +237,18 @@ PUDL_DB: /Users/me/databases/pudl.db
 EIA_AEO_YEAR: 2023
 ```
 
+`RESOURCE_GROUPS` and `RESOURCE_GROUP_PROFILES` accept **either a single path or a
+list of paths**, so data can be split across multiple folders:
+
+```yaml
+RESOURCE_GROUPS:
+  - /Users/me/resource_groups/onshore
+  - /Users/me/resource_groups/offshore
+RESOURCE_GROUP_PROFILES:
+  - /Users/me/nrel_profiles/wind
+  - /Users/me/nrel_profiles/solar
+```
+
 **settings/.gitignore**:
 
 ```text

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -278,6 +278,10 @@ PowerGenome respects these environment variables (legacy, prefer settings YAML):
 - `RESOURCE_GROUP_PROFILES`: Path to generation profiles
 - `EFS_DATA`: Path to NREL EFS electrification data
 
+Environment variables are always single paths. When using settings YAML,
+`RESOURCE_GROUPS` and `RESOURCE_GROUP_PROFILES` may instead be a list of paths
+(split across multiple folders).
+
 !!! warning "Deprecated"
     Using environment variables for paths is deprecated. Use settings YAML parameters instead:
 

--- a/docs/reference/settings/data-tables.md
+++ b/docs/reference/settings/data-tables.md
@@ -326,10 +326,39 @@ dg_profiles_table: dg_generation_profiles.parquet
 
 ## Renewable Resource Tables
 
+### Resource Groups
+
+**Setting**: `RESOURCE_GROUPS` (path, or list of paths)
+**Purpose**: Folder(s) containing renewable resource group definition JSON files
+(one JSON per resource group). All `.json` files are discovered recursively in
+each configured folder, so you can point at a single folder or split the JSON files
+across several folders.
+
+**Example**:
+
+```yaml
+RESOURCE_GROUPS: /data/resource_groups
+```
+
+Or from multiple folders:
+
+```yaml
+RESOURCE_GROUPS:
+  - /data/resource_groups/onshore
+  - /data/resource_groups/offshore
+```
+
 ### Resource Group Profiles
 
-**Setting**: `RESOURCE_GROUP_PROFILES` (path)
+**Setting**: `RESOURCE_GROUP_PROFILES` (path, or list of paths)
 **Purpose**: Hourly generation profiles for renewable clusters
+
+`RESOURCE_GROUP_PROFILES` accepts either a single folder or a list of folders.
+When a list is provided, each profile file named in a resource group JSON is
+searched for in the listed folders (in order, plus the `RESOURCE_GROUP_PROFILES`
+environment variable if set) before falling back to the resource group JSON's own
+folder. This lets you, for example, keep wind profiles in one folder and solar
+profiles in another.
 
 **File naming**: `{technology}_profiles_{suffix}.csv` or `.parquet`
 
@@ -344,6 +373,14 @@ dg_profiles_table: dg_generation_profiles.parquet
 
 ```yaml
 RESOURCE_GROUP_PROFILES: /data/nrel_profiles/
+```
+
+Or from multiple folders:
+
+```yaml
+RESOURCE_GROUP_PROFILES:
+  - /data/nrel_profiles/wind
+  - /data/nrel_profiles/solar
 ```
 
 Files in folder:

--- a/powergenome/new_build.py
+++ b/powergenome/new_build.py
@@ -1314,8 +1314,13 @@ def add_renewables_clusters(
         cache_cluster_fn = unique_hash + "_cluster_data.parquet"
         cache_site_assn_fn = unique_hash + "_site_assn.parquet"
 
-        sub_folder = settings.get("RESOURCE_GROUPS") or SETTINGS.get("RESOURCE_GROUPS")
-        sub_folder = str(sub_folder).replace("/", "_").replace("\\", "_")
+        rg_paths = settings.get("RESOURCE_GROUPS") or SETTINGS.get("RESOURCE_GROUPS")
+        if isinstance(rg_paths, list):
+            sub_folder = "__".join(
+                str(p).replace("/", "_").replace("\\", "_") for p in rg_paths
+            )
+        else:
+            sub_folder = str(rg_paths).replace("/", "_").replace("\\", "_")
         cache_folder = Path(
             settings["input_folder"] / "cluster_assignments" / sub_folder
         )

--- a/powergenome/params.py
+++ b/powergenome/params.py
@@ -4,7 +4,7 @@ Parameters and settings
 
 import os
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 from dotenv import load_dotenv
 
@@ -45,18 +45,26 @@ SETTINGS["RESOURCE_GROUP_PROFILES"] = os.environ.get("RESOURCE_GROUP_PROFILES")
 
 
 def build_resource_clusters(
-    group_path: Union[str, Path] = None, profile_path: Union[str, Path] = None
+    group_path: Union[str, Path, List[Union[str, Path]]] = None,
+    profile_path: Union[str, Path, List[Union[str, Path]]] = None,
 ) -> ClusterBuilder:
     if not group_path:
         group_path = SETTINGS.get("RESOURCE_GROUPS")
     if not profile_path:
         profile_path = SETTINGS.get("RESOURCE_GROUP_PROFILES")
     if profile_path is not None:
-        profile_path = Path(profile_path)
+        if isinstance(profile_path, list):
+            profile_path = [Path(p) for p in profile_path]
+        else:
+            profile_path = Path(profile_path)
     if not group_path:
         cluster_builder = ClusterBuilder([])
     else:
-        cluster_builder = ClusterBuilder.from_json(
-            Path(group_path, ".").glob("**/*.json"), profile_path
-        )
+        group_paths = group_path if isinstance(group_path, list) else [group_path]
+        json_paths = [
+            json_file
+            for gp in group_paths
+            for json_file in Path(gp, ".").glob("**/*.json")
+        ]
+        cluster_builder = ClusterBuilder.from_json(json_paths, profile_path)
     return cluster_builder

--- a/powergenome/resource_clusters.py
+++ b/powergenome/resource_clusters.py
@@ -478,33 +478,41 @@ class ResourceGroup:
         metadata: pd.DataFrame = None,
         profiles: pd.DataFrame = None,
         path: str = ".",
-        profile_path: str = None,
+        profile_path: Union[str, os.PathLike, List[Union[str, os.PathLike]]] = None,
     ) -> None:
         from powergenome.params import SETTINGS
 
         self.group = {"existing": False, "tree": None, **group.copy()}
 
         # Convert relative paths (relative to group file) to absolute paths
-        # Profiles may be stored in a single location and reused across resource groups
+        # Profiles may be stored in one or more locations (a single path or a list)
+        # and reused across resource groups. Candidate roots are checked in order:
+        # the location passed as an arg (probably from settings), then SETTINGS
+        # (from the .env file), then assumed to be in the same folder as the JSON file.
         if self.group.get("metadata"):
             self.group["metadata"] = Path(path) / self.group["metadata"]
         if self.group.get("profiles"):
-            # Check for location passed as an arg (probably from settings file),
-            # then the SETTINGS (from .env file), then assume they are in the same folder
-            # as the JSON file
-            if profile_path and (profile_path / self.group["profiles"]).exists():
-                self.group["profiles"] = Path(profile_path) / self.group["profiles"]
-            elif (
-                SETTINGS.get("RESOURCE_GROUP_PROFILES")
-                and (
-                    Path(SETTINGS["RESOURCE_GROUP_PROFILES"]) / self.group["profiles"]
-                ).exists()
-            ):
-                self.group["profiles"] = (
-                    Path(SETTINGS["RESOURCE_GROUP_PROFILES"]) / self.group["profiles"]
+            profile_roots = []
+            if profile_path:
+                profile_roots.extend(
+                    profile_path if isinstance(profile_path, list) else [profile_path]
                 )
-            else:
-                self.group["profiles"] = Path(path) / self.group["profiles"]
+            settings_profiles = SETTINGS.get("RESOURCE_GROUP_PROFILES")
+            if settings_profiles:
+                profile_roots.extend(
+                    settings_profiles
+                    if isinstance(settings_profiles, list)
+                    else [settings_profiles]
+                )
+            resolved_profiles = None
+            for root in profile_roots:
+                candidate = Path(root) / self.group["profiles"]
+                if candidate.exists():
+                    resolved_profiles = candidate
+                    break
+            if resolved_profiles is None:
+                resolved_profiles = Path(path) / self.group["profiles"]
+            self.group["profiles"] = resolved_profiles
         required = ["technology"]
         if metadata is None:
             required.append("metadata")
@@ -520,7 +528,9 @@ class ResourceGroup:
 
     @classmethod
     def from_json(
-        cls, path: Union[str, os.PathLike], profile_path: Union[str, os.PathLike] = None
+        cls,
+        path: Union[str, os.PathLike],
+        profile_path: Union[str, os.PathLike, List[Union[str, os.PathLike]]] = None,
     ) -> "ResourceGroup":
         """
         Build from JSON file.
@@ -950,7 +960,7 @@ class ClusterBuilder:
     def from_json(
         cls,
         paths: Iterable[Union[str, os.PathLike]],
-        profile_path: Union[str, os.PathLike] = None,
+        profile_path: Union[str, os.PathLike, List[Union[str, os.PathLike]]] = None,
     ) -> "ClusterBuilder":
         """
         Load resources from resource group JSON files.

--- a/powergenome/settings.py
+++ b/powergenome/settings.py
@@ -699,8 +699,12 @@ def load_settings(path: Union[str, Path]) -> dict:
         "DISTRIBUTED_GEN_DATA",
         "RESOURCE_GROUP_PROFILES",
     ]:
-        if settings.get(key):
-            settings[key] = Path(settings[key])
+        value = settings.get(key)
+        if value:
+            if isinstance(value, list):
+                settings[key] = [Path(v) for v in value]
+            else:
+                settings[key] = Path(value)
 
     settings["model_regions"] = sorted(settings["model_regions"])
     zones = settings["model_regions"]

--- a/tests/resource_clusters_test.py
+++ b/tests/resource_clusters_test.py
@@ -233,7 +233,10 @@ class TestReadProfiles:
         self, resource_group_tidy_weather, caplog
     ):
         """Tidy multiyear without explicit weather_year: concatenates all years."""
-        with caplog.at_level(logging.DEBUG):
+        # Target the module logger explicitly: settings_test imports set the
+        # parent "powergenome" logger to INFO, which would otherwise suppress
+        # the DEBUG record regardless of the root logger level.
+        with caplog.at_level(logging.DEBUG, logger="powergenome.resource_clusters"):
             result = resource_group_tidy_weather._read_profiles(site_ids=[0])
         assert "concatenating all available years" in caplog.text
         assert len(result) == 48  # 2 years × 24h

--- a/tests/resource_clusters_test.py
+++ b/tests/resource_clusters_test.py
@@ -409,6 +409,12 @@ class TestBuildResourceClusters:
             "landbasedwind",
         }
 
-    def test_no_groups_returns_empty(self):
+    def test_no_groups_returns_empty(self, monkeypatch):
+        # CI sets RESOURCE_GROUPS via the environment (loaded into SETTINGS at
+        # import time), so clear it to keep this test hermetic.
+        import powergenome.params as params
+
+        monkeypatch.setitem(params.SETTINGS, "RESOURCE_GROUPS", None)
+        monkeypatch.setitem(params.SETTINGS, "RESOURCE_GROUP_PROFILES", None)
         builder = build_resource_clusters(group_path=None)
         assert len(builder.groups) == 0

--- a/tests/resource_clusters_test.py
+++ b/tests/resource_clusters_test.py
@@ -1,11 +1,13 @@
 """Tests for resource_clusters.py — ResourceGroup._read_profiles and test_profiles."""
 
+import json
 import logging
 
 import numpy as np
 import pandas as pd
 import pytest
 
+from powergenome.params import build_resource_clusters
 from powergenome.resource_clusters import ResourceGroup
 
 
@@ -295,3 +297,115 @@ class TestTestProfiles:
         rg = ResourceGroup(group, metadata=metadata_df, profiles=bad_wide)
         with pytest.raises(ValueError, match="not a multiple of 8760 or 8784"):
             rg.test_profiles()
+
+
+# ── Profile path resolution (single path or list) ─────────────────────
+
+
+def _write_group(tmp_path, technology, metadata, profiles):
+    """Write a minimal resource group alongside its metadata file."""
+    (tmp_path / "meta.csv").write_text("id,region,capacity_mw\n1,A,10\n")
+    group = {
+        "technology": technology,
+        "metadata": metadata,
+        "profiles": profiles,
+    }
+    return group
+
+
+class TestProfilePathList:
+    """Profile files may live in any of several listed profile folders."""
+
+    def test_profile_resolved_from_first_matching_root(self, tmp_path):
+        root_a = tmp_path / "profiles_a"
+        root_a.mkdir()
+        root_b = tmp_path / "profiles_b"
+        root_b.mkdir()
+        (root_a / "pv_profiles.csv").write_text("0\n0.5\n")
+
+        group = _write_group(tmp_path, "utilitypv", "meta.csv", "pv_profiles.csv")
+        rg = ResourceGroup(group, path=str(tmp_path), profile_path=[root_a, root_b])
+
+        assert rg.group["profiles"] == root_a / "pv_profiles.csv"
+
+    def test_profile_searched_in_later_listed_root(self, tmp_path):
+        root_a = tmp_path / "profiles_a"
+        root_a.mkdir()
+        root_b = tmp_path / "profiles_b"
+        root_b.mkdir()
+        (root_b / "wind_profiles.csv").write_text("0\n0.5\n")
+
+        group = _write_group(tmp_path, "landbasedwind", "meta.csv", "wind_profiles.csv")
+        rg = ResourceGroup(group, path=str(tmp_path), profile_path=[root_a, root_b])
+
+        assert rg.group["profiles"] == root_b / "wind_profiles.csv"
+
+    def test_falls_back_to_group_folder_when_no_root_matches(self, tmp_path):
+        root = tmp_path / "profiles"
+        root.mkdir()
+        (tmp_path / "profiles.csv").write_text("0\n0.5\n")
+
+        group = _write_group(tmp_path, "utilitypv", "meta.csv", "profiles.csv")
+        rg = ResourceGroup(group, path=str(tmp_path), profile_path=[root])
+
+        assert rg.group["profiles"] == tmp_path / "profiles.csv"
+
+    def test_settins_list_profile_roots_are_checked(self, tmp_path, monkeypatch):
+        import powergenome.params as params
+
+        root = tmp_path / "profiles"
+        root.mkdir()
+        (root / "solar_profiles.csv").write_text("0\n0.5\n")
+        monkeypatch.setitem(
+            params.SETTINGS,
+            "RESOURCE_GROUP_PROFILES",
+            [tmp_path / "missing", root],
+        )
+
+        group = _write_group(tmp_path, "utilitypv", "meta.csv", "solar_profiles.csv")
+        rg = ResourceGroup(group, path=str(tmp_path))
+
+        assert rg.group["profiles"] == root / "solar_profiles.csv"
+
+
+class TestBuildResourceClusters:
+    """Resource group JSONs may be spread across multiple folders."""
+
+    def test_single_group_folder(self, tmp_path):
+        g = tmp_path / "groups"
+        g.mkdir()
+        (g / "a.json").write_text(
+            json.dumps({"technology": "utilitypv", "metadata": "meta.csv"})
+        )
+        (g / "meta.csv").write_text("id,region,capacity_mw\n1,A,10\n")
+
+        builder = build_resource_clusters(group_path=g)
+
+        assert len(builder.groups) == 1
+        assert builder.groups[0].group["technology"] == "utilitypv"
+
+    def test_multiple_group_folders(self, tmp_path):
+        g1 = tmp_path / "groups_a"
+        g1.mkdir()
+        g2 = tmp_path / "groups_b"
+        g2.mkdir()
+        (g1 / "a.json").write_text(
+            json.dumps({"technology": "utilitypv", "metadata": "meta.csv"})
+        )
+        (g2 / "b.json").write_text(
+            json.dumps({"technology": "landbasedwind", "metadata": "meta.csv"})
+        )
+        (g1 / "meta.csv").write_text("id,region,capacity_mw\n1,A,10\n")
+        (g2 / "meta.csv").write_text("id,region,capacity_mw\n2,A,20\n")
+
+        builder = build_resource_clusters(group_path=[g1, g2])
+
+        assert len(builder.groups) == 2
+        assert {g.group["technology"] for g in builder.groups} == {
+            "utilitypv",
+            "landbasedwind",
+        }
+
+    def test_no_groups_returns_empty(self):
+        builder = build_resource_clusters(group_path=None)
+        assert len(builder.groups) == 0

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1546,6 +1546,25 @@ class TestExpandCapacityReserveValues:
         assert result["data_location"] == tmp_path / "test_data"
         assert result["input_folder"] == tmp_path / "extra_inputs"
 
+    def test_resource_group_paths_accept_single_or_list(self, tmp_path):
+        """RESOURCE_GROUPS / RESOURCE_GROUP_PROFILES accept a single path or a list."""
+        settings_folder = tmp_path / "settings"
+        settings_folder.mkdir()
+        settings_file = settings_folder / "data.yml"
+        settings_content = {
+            "model_regions": ["p1"],
+            "RESOURCE_GROUPS": ["groups_a", "groups_b"],
+            "RESOURCE_GROUP_PROFILES": "profiles",
+        }
+
+        with open(settings_file, "w") as f:
+            yaml.dump(settings_content, f)
+
+        result = load_settings(settings_file)
+
+        assert result["RESOURCE_GROUPS"] == [Path("groups_a"), Path("groups_b")]
+        assert result["RESOURCE_GROUP_PROFILES"] == Path("profiles")
+
     def test_integration_with_build_scenario_settings(self, tmp_path):
         """Test that expand_capacity_reserve_values works in scenario building."""
         # Create base settings

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -329,6 +329,25 @@ class TestCheckPathsExist:
         results = _check_paths_exist(s)
         assert any("RESOURCE_GROUPS" in r.message for r in _errors(results))
 
+    def test_existing_resource_groups_list(self, tmp_path):
+        locations = [tmp_path / "groups_a", tmp_path / "groups_b"]
+        for location in locations:
+            location.mkdir()
+        s = {"RESOURCE_GROUPS": locations}
+        assert _errors(_check_paths_exist(s)) == []
+
+    def test_existing_resource_group_profiles_list(self, tmp_path):
+        locations = [tmp_path / "profiles_a", tmp_path / "profiles_b"]
+        for location in locations:
+            location.mkdir()
+        s = {"RESOURCE_GROUP_PROFILES": locations}
+        assert _errors(_check_paths_exist(s)) == []
+
+    def test_missing_resource_groups_in_list(self, tmp_path):
+        locations = [tmp_path, tmp_path / "no_such_groups"]
+        results = _check_paths_exist({"RESOURCE_GROUPS": locations})
+        assert any("RESOURCE_GROUPS" in r.message for r in _errors(results))
+
     def test_existing_input_folder_with_scenario_file(self, tmp_path):
         scenario_file = tmp_path / "scenarios.csv"
         scenario_file.write_text("case_id,year\nbaseline,2030\n")


### PR DESCRIPTION
## Motivation

`data_location` has long accepted either a single location or a list of locations, but `RESOURCE_GROUPS` and `RESOURCE_GROUP_PROFILES` were limited to a single path. Users who split renewable resource data across folders (e.g. wind profile files in one folder and solar in another, or resource group JSONs across several directories) had no supported way to express that in settings. This PR makes both parameters accept a single path or a list of paths, mirroring `data_location`.

## Approach

- **`powergenome/settings.py`**: the `load_settings` path-conversion step now handles list values, converting each element to `Path` (single values behave exactly as before).
- **`powergenome/params.py`**: `build_resource_clusters` accepts a single folder or a list of folders for `RESOURCE_GROUPS`, globbing `**/*.json` across every folder and combining the results. `profile_path` (single or list) is passed through unchanged.
- **`powergenome/resource_clusters.py`**: `ResourceGroup` resolves each profile file named in a JSON against the candidate profile roots in priority order (the `profile_path` argument, then `RESOURCE_GROUP_PROFILES` from the `.env`/`SETTINGS`, then the resource group JSON's own folder), picking the first root where the file exists. This preserves the existing precedence while allowing profiles to be spread across folders.
- **`powergenome/new_build.py`**: the cluster cache sub-folder name is derived deterministically from `RESOURCE_GROUPS` when it is a list (sanitized paths joined with `__`) instead of calling `str()` on the list.
- **`powergenome/validate.py`**: `_check_paths_exist` already supported list values; no change was needed, but tests were added to lock in the behavior.

## Tests

Added coverage for list handling at each consumption point:

- `load_settings` converts single or list values to the right `Path`/list-of-`Path` shape.
- `_check_paths_exist` validates single or list `RESOURCE_GROUPS` / `RESOURCE_GROUP_PROFILES`.
- `ResourceGroup` resolves profiles from the first matching listed root, a later listed root, and falls back to the JSON folder when no root matches; also covers SETTINGS-provided list roots.
- `build_resource_clusters` discovers group JSONs from a single folder, multiple folders, and none.

Full test suite passes (808 passed).

## Notes for reviewers

- Environment variables (`RESOURCE_GROUPS`, `RESOURCE_GROUP_PROFILES` in `.env`) remain single paths; only the settings-YAML form supports lists.
- Profile resolution is order-sensitive: when a profile file exists in multiple listed folders, the first folder in the list wins.
- Docs updated in `docs/reference/settings/data-tables.md` (new Resource Groups section plus list examples), `docs/how-to/configure-settings.md`, and `docs/reference/cli.md`.