### PR TITLE
Rename policy/segment data settings to *_table, keep *_fn alias

### DIFF
--- a/docs/explanation/pipeline.md
+++ b/docs/explanation/pipeline.md
@@ -121,7 +121,7 @@ agg_transmission_constraints() → insert_tx_costs() → network_*()
 - Adds line loss percentages and expansion cost parameters
 - Builds the `Network.csv` content
 
-Policy files (RPS, CO₂ caps, minimum/maximum capacity constraints) are also assembled in this stage from files referenced by `emission_policies_fn`, `energy_share_req_fn`, etc.
+Policy files (RPS, CO₂ caps, minimum/maximum capacity constraints) are also assembled in this stage from files referenced by `emission_policies_table` (legacy alias: `emission_policies_fn`), `energy_share_req_fn`, etc.
 
 **Key outputs**: `network`, `esr`, `co2_cap`, `min_cap`, `max_cap`, `cap_reserves` DataFrames.
 

--- a/docs/how-to/configure-settings.md
+++ b/docs/how-to/configure-settings.md
@@ -467,7 +467,7 @@ Configure renewable portfolio standards:
 **settings/policies.yml**:
 
 ```yaml
-emission_policies_fn: emission_policies.csv
+emission_policies_table: emission_policies.csv
 energy_share_req_fn: energy_share_requirements.csv
 ```
 

--- a/docs/how-to/energy-share-requirements.md
+++ b/docs/how-to/energy-share-requirements.md
@@ -89,11 +89,12 @@ alternative,2030,all,baseline,
 ```yaml
 # settings/policies.yml
 input_folder: extra_inputs
-emission_policies_fn: emission_policies.csv
+emission_policies_table: emission_policies.csv
 ```
 
-`emission_policies_fn` is loaded through the DataManager, so the value may use
-any supported DataManager table configuration rather than only a CSV path.
+`emission_policies_table` is loaded through the DataManager, so the value may use
+any supported DataManager table configuration rather than only a CSV path. The
+legacy `emission_policies_fn` key is still accepted as an alias.
 
 ---
 
@@ -168,7 +169,7 @@ Cross-check that the technologies you expect to be eligible are marked `1`.
 
 **ESR columns missing from output**
 
-Confirm `emission_policies_fn` is set in settings and the file is in `input_folder`. If the CSV has no `ESR_*` columns, no ESR output is produced.
+Confirm `emission_policies_table` is set in settings and the file is in `input_folder`. If the CSV has no `ESR_*` columns, no ESR output is produced.
 
 **Resources not marked as eligible**
 

--- a/docs/reference/settings/data-tables.md
+++ b/docs/reference/settings/data-tables.md
@@ -407,12 +407,15 @@ weather_year,time_index,site_id,value
 
 ### Emission Policies
 
-**Setting**: `emission_policies_fn`
+**Setting**: `emission_policies_table`
 **Purpose**: RPS, CES, carbon constraints by case/region/year
 
 This setting names a DataManager table source. It can use the same file or
 database table configuration supported by other DataManager inputs; it is not
 limited to a CSV in `input_folder`.
+
+The legacy `emission_policies_fn` key is still accepted as an alias; if both
+are set, `emission_policies_table` takes precedence.
 
 **Required columns**:
 
@@ -429,16 +432,18 @@ limited to a CSV in `input_folder`.
 **Example**:
 
 ```yaml
-emission_policies_fn: emission_policies.csv
+emission_policies_table: emission_policies.csv
 ```
 
 ### Demand Segments
 
-**Setting**: `demand_segments_fn`
+**Setting**: `demand_segments_table`
 **Purpose**: Value of lost load and demand segmentation parameters
 
 This setting names a DataManager table source and supports the same file and
-database table configurations as other DataManager inputs.
+database table configurations as other DataManager inputs. The legacy
+`demand_segments_fn` key is still accepted as an alias; if both are set,
+`demand_segments_table` takes precedence.
 
 ### Cost Multipliers
 

--- a/docs/reference/settings/resource-tags.md
+++ b/docs/reference/settings/resource-tags.md
@@ -232,7 +232,7 @@ model_tag_values:
     NaturalGas: 1  # Counts toward gas maximum
 ```
 
-Configure requirements in `emission_policies_fn` or via GenX settings.
+Configure requirements in `emission_policies_table` (legacy alias: `emission_policies_fn`) or via GenX settings.
 
 ## Capacity Reserve Tags
 

--- a/powergenome/GenX.py
+++ b/powergenome/GenX.py
@@ -401,7 +401,8 @@ def add_emission_policies(transmission_df, settings=None):
     settings : dict
         User-defined parameters from a settings file. Should have keys of `input_folder`
         (a Path object of where to find user-supplied data) and
-        `emission_policies_fn` (the file to load).
+        `emission_policies_table` (the file to load; the legacy
+        `emission_policies_fn` key is also accepted as an alias).
     DistrZones : [type], optional
         Placeholder setting, by default None
 

--- a/powergenome/database.py
+++ b/powergenome/database.py
@@ -55,8 +55,8 @@ class DataManager:
         "regional_cost_factor_table": "regional_cost_factor",
         "transmission_cost_table": "transmission_cost",
         "demand_table": "demand",
-        "emission_policies_fn": "emission_policies",
-        "demand_segments_fn": "demand_segments",
+        "emission_policies_table": "emission_policies",
+        "demand_segments_table": "demand_segments",
         # Supplemental demand table for adding extra hourly load (e.g. data center forecasts).
         "supplemental_demand_table": "supplemental_demand",
         # Distributed generation tables (support both legacy and new setting keys).
@@ -64,6 +64,13 @@ class DataManager:
         "distributed_profile_table": "distributed_profiles",  # singular key
         "distributed_profiles_table": "distributed_profiles",  # plural key
         "distributed_capacity_table": "distributed_capacity",
+    }
+
+    # Legacy settings keys kept as aliases for backward compatibility. When the
+    # canonical (``*_table``) key is not set, its alias value is used instead.
+    STANDARD_TABLE_ALIASES = {
+        "emission_policies_table": "emission_policies_fn",
+        "demand_segments_table": "demand_segments_fn",
     }
 
     def __new__(cls):
@@ -186,7 +193,7 @@ class DataManager:
         self.available_tables.clear()
 
         for setting_key, standard_name in self.STANDARD_TABLE_MAPPING.items():
-            table_config = self.settings.get(setting_key)
+            table_config = get_table_setting_value(self.settings, setting_key)
 
             if not table_config:
                 continue
@@ -794,7 +801,7 @@ class DataManager:
         # Find tables where configuration has changed
         tables_to_update = set()
         for setting_key, standard_name in self.STANDARD_TABLE_MAPPING.items():
-            new_config = self.settings.get(setting_key)
+            new_config = get_table_setting_value(self.settings, setting_key)
             old_config = self.table_configurations.get(standard_name, {}).get("config")
 
             if new_config != old_config:
@@ -813,7 +820,7 @@ class DataManager:
                 logger.warning(f"Could not find setting key for table {standard_name}")
                 continue
 
-            table_config = self.settings.get(setting_key)
+            table_config = get_table_setting_value(self.settings, setting_key)
 
             if not table_config:
                 # Remove table if no longer configured
@@ -884,6 +891,33 @@ class DataManager:
 
 # Convenience functions for global access
 _data_manager = DataManager()
+
+
+def get_table_setting_value(settings, setting_key: str):
+    """Return the configured value for a DataManager table setting key.
+
+    Falls back to the legacy alias key (``DataManager.STANDARD_TABLE_ALIASES``)
+    when the canonical key is not set, so old ``*_fn`` settings keep working.
+    The canonical key takes precedence when both are configured.
+
+    Parameters
+    ----------
+    settings : Union[Dict[str, Any], Settings]
+        Settings dictionary or Settings object
+    setting_key : str
+        A canonical table setting key (e.g. ``"emission_policies_table"``)
+
+    Returns
+    -------
+    Any
+        The configured value, or ``None`` if the key (and any alias) is unset.
+    """
+    value = settings.get(setting_key)
+    if value is None:
+        alias = DataManager.STANDARD_TABLE_ALIASES.get(setting_key)
+        if alias is not None:
+            value = settings.get(alias)
+    return value
 
 
 def initialize_data_manager(

--- a/powergenome/external_data.py
+++ b/powergenome/external_data.py
@@ -279,7 +279,8 @@ def load_policy_scenarios(settings: dict = None) -> pd.DataFrame:
     settings : dict
         User-defined parameters from a settings file. Should have keys of `input_folder`
         (a Path object of where to find user-supplied data) and
-        `emission_policies_fn` (the file to load).
+        `emission_policies_table` (the file to load; the legacy
+        `emission_policies_fn` key is also accepted as an alias).
 
     Returns
     -------
@@ -380,7 +381,8 @@ def load_demand_segments(settings):
     ----------
     settings : dict
         User defined PowerGenome settings. Must have the keys "input_folder" and
-        "demand_segments_fn".
+        "demand_segments_table" (the legacy "demand_segments_fn" key is also
+        accepted as an alias).
 
     Returns
     -------

--- a/powergenome/macro_inputs.py
+++ b/powergenome/macro_inputs.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional
 import numpy as np
 import pandas as pd
 
+from powergenome.database import get_table_setting_value
 from powergenome.external_data import load_demand_segments
 
 logger = logging.getLogger(__name__)
@@ -841,7 +842,7 @@ def load_nsd_segments(settings: dict) -> tuple:
     """
     default_max_nsd = float(settings.get("macro_default_max_nsd", 1))
     default_voll = float(settings.get("macro_default_voll", 10000.0))
-    fn = settings.get("demand_segments_fn")
+    fn = get_table_setting_value(settings, "demand_segments_table")
     if not fn:
         return [default_max_nsd], [default_voll]
     try:

--- a/powergenome/run_powergenome.py
+++ b/powergenome/run_powergenome.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import pandas as pd
 
 import powergenome
-from powergenome.database import initialize_data_manager, update_data_manager
+from powergenome.database import (
+    get_table_setting_value,
+    initialize_data_manager,
+    update_data_manager,
+)
 
 logger = logging.getLogger(__name__)
 from powergenome.external_data import make_generator_variability
@@ -518,7 +522,9 @@ def main(**kwargs):
                             )
                     case_year_data["network"] = network
 
-                    if scenario_settings_obj.get("emission_policies_fn"):
+                    if get_table_setting_value(
+                        scenario_settings_obj, "emission_policies_table"
+                    ):
                         energy_share_req = create_policy_req(
                             col_str_match="ESR",
                         )

--- a/powergenome/validate.py
+++ b/powergenome/validate.py
@@ -864,6 +864,7 @@ def _check_data_tables_loaded(settings: dict, dm: Any) -> List[ValidationResult]
 
     try:
         from powergenome.database import DataManager as _DM
+        from powergenome.database import get_table_setting_value
 
         mapping = _DM.STANDARD_TABLE_MAPPING
     except Exception:
@@ -871,7 +872,10 @@ def _check_data_tables_loaded(settings: dict, dm: Any) -> List[ValidationResult]
 
     available = dm.available_tables or set()
     for setting_key, standard_name in mapping.items():
-        if settings.get(setting_key) and standard_name not in available:
+        if (
+            get_table_setting_value(settings, setting_key)
+            and standard_name not in available
+        ):
             results.append(
                 _err(
                     "data_tables",

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -590,7 +590,7 @@ class TestMainFunction:
         mock_resolve.return_value = {}
 
         # Make scenario_settings_obj.get() return falsy defaults to skip
-        # optional pipeline sections (reserves_fn, emission_policies_fn, etc.)
+        # optional pipeline sections (reserves_fn, emission_policies_table, etc.)
         scenario_obj = MagicMock()
         scenario_obj.get.side_effect = lambda k, d=None: d
         mock_settings_class.for_scenario.return_value.__enter__.return_value = (

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -163,6 +163,21 @@ class TestDataManager:
         dm = DataManager()
         dm.initialize(
             {
+                "emission_policies_table": {"table_name": "policies.csv"},
+                "demand_segments_table": {"table_name": "segments.csv"},
+            },
+            temp_csv_folder,
+        )
+
+        assert {"emission_policies", "demand_segments"} <= dm.available_tables
+        assert dm.get_data("emission_policies").iloc[0]["case_id"] == "base"
+        assert dm.get_data("demand_segments").iloc[0]["Voll"] == 1000
+
+    def test_initialization_policy_tables_legacy_fn_alias(self, temp_csv_folder):
+        """Legacy ``*_fn`` settings keys still configure the same tables."""
+        dm = DataManager()
+        dm.initialize(
+            {
                 "emission_policies_fn": {"table_name": "policies.csv"},
                 "demand_segments_fn": {"table_name": "segments.csv"},
             },
@@ -172,6 +187,22 @@ class TestDataManager:
         assert {"emission_policies", "demand_segments"} <= dm.available_tables
         assert dm.get_data("emission_policies").iloc[0]["case_id"] == "base"
         assert dm.get_data("demand_segments").iloc[0]["Voll"] == 1000
+
+    def test_initialization_policy_tables_table_key_takes_precedence(
+        self, temp_csv_folder
+    ):
+        """When both ``*_table`` and legacy ``*_fn`` are set, ``*_table`` wins."""
+        dm = DataManager()
+        dm.initialize(
+            {
+                "emission_policies_table": "policies.csv",
+                "emission_policies_fn": "does_not_exist.csv",
+            },
+            temp_csv_folder,
+        )
+
+        assert "emission_policies" in dm.available_tables
+        assert dm.get_data("emission_policies").iloc[0]["case_id"] == "base"
 
     def test_initialization_multiple_locations(
         self, sample_settings_csv, temp_csv_folder, tmp_path

--- a/tests/external_data_test.py
+++ b/tests/external_data_test.py
@@ -14,7 +14,7 @@ def test_load_demand_segments_uses_data_manager(monkeypatch):
     monkeypatch.setattr(external_data, "get_data", fake_get_data)
 
     result = external_data.load_demand_segments(
-        {"demand_segments_fn": "segments.parquet"}
+        {"demand_segments_table": "segments.parquet"}
     )
 
     pd.testing.assert_frame_equal(result, expected)
@@ -28,7 +28,7 @@ def test_load_policy_scenarios_uses_data_manager(monkeypatch):
     monkeypatch.setattr(external_data, "get_data", lambda table_name: expected)
 
     result = external_data.load_policy_scenarios(
-        {"emission_policies_fn": "policies.parquet", "case_id": "base"}
+        {"emission_policies_table": "policies.parquet", "case_id": "base"}
     )
 
     assert result.index.names == ["case_id", "year"]

--- a/tests/macro_test.py
+++ b/tests/macro_test.py
@@ -71,8 +71,10 @@ def _reset_data_manager():
 
 def _init_dm_for_folder(folder):
     """Initialize the DataManager against a folder so ``get_data`` can resolve
-    the ``demand_segments`` table from the ``demand_segments_fn`` setting."""
-    initialize_data_manager({"demand_segments_fn": "demand_segments_voll.csv"}, folder)
+    the ``demand_segments`` table from the ``demand_segments_table`` setting."""
+    initialize_data_manager(
+        {"demand_segments_table": "demand_segments_voll.csv"}, folder
+    )
 
 
 @pytest.fixture
@@ -657,13 +659,34 @@ def test_load_nsd_segments_from_demand_segments_csv(tmp_path):
     )
     settings = {
         "input_folder": str(tmp_path),
-        "demand_segments_fn": "demand_segments_voll.csv",
+        "demand_segments_table": "demand_segments_voll.csv",
     }
     _init_dm_for_folder(tmp_path)
     max_nsd, price_nsd = load_nsd_segments(settings)
     # Sorted by descending cost: 2000, 1800, 1100, 400
     assert price_nsd == [2000.0, 1800.0, 1100.0, 400.0]
     assert max_nsd == [1.0, 0.04, 0.024, 0.003]
+
+
+def test_load_nsd_segments_legacy_fn_alias(tmp_path):
+    """The legacy ``demand_segments_fn`` setting still configures Macro NSD."""
+    seg_csv = tmp_path / "demand_segments_voll.csv"
+    seg_csv.write_text(
+        "Voll,Demand_Segment,Cost_of_Demand_Curtailment_per_MW,"
+        "Max_Demand_Curtailment,$/MWh\n"
+        "2000,1,1,1,2000\n"
+        ",2,0.9,0.04,1800\n"
+    )
+    settings = {
+        "input_folder": str(tmp_path),
+        "demand_segments_fn": "demand_segments_voll.csv",
+    }
+    initialize_data_manager(
+        {"demand_segments_fn": "demand_segments_voll.csv"}, tmp_path
+    )
+    max_nsd, price_nsd = load_nsd_segments(settings)
+    assert price_nsd == [2000.0, 1800.0]
+    assert max_nsd == [1.0, 0.04]
 
 
 def test_load_nsd_segments_default_when_no_file():
@@ -692,7 +715,7 @@ def test_load_nsd_segments_uses_voll_base_price(tmp_path):
     )
     settings = {
         "input_folder": str(tmp_path),
-        "demand_segments_fn": "demand_segments_voll.csv",
+        "demand_segments_table": "demand_segments_voll.csv",
     }
     _init_dm_for_folder(tmp_path)
     max_nsd, price_nsd = load_nsd_segments(settings)
@@ -709,7 +732,7 @@ def test_load_nsd_segments_falls_back_to_per_mwh(tmp_path):
     )
     settings = {
         "input_folder": str(tmp_path),
-        "demand_segments_fn": "demand_segments_voll.csv",
+        "demand_segments_table": "demand_segments_voll.csv",
     }
     _init_dm_for_folder(tmp_path)
     max_nsd, price_nsd = load_nsd_segments(settings)
@@ -730,7 +753,7 @@ def test_make_nodes_json_uses_demand_segments(tmp_path):
         "model_regions": ["R1"],
         "zone_num_map": {"R1": 1},
         "input_folder": str(tmp_path),
-        "demand_segments_fn": "demand_segments_voll.csv",
+        "demand_segments_table": "demand_segments_voll.csv",
     }
     _init_dm_for_folder(tmp_path)
     nodes = make_nodes_json(
@@ -1402,7 +1425,7 @@ def test_load_nsd_segments_error_and_missing_column_fallbacks(tmp_path):
     # File configured but missing on disk -> load raises, caught and defaulted
     missing_file_settings = {
         "input_folder": str(tmp_path),
-        "demand_segments_fn": "does_not_exist.csv",
+        "demand_segments_table": "does_not_exist.csv",
         "macro_default_max_nsd": 0.8,
         "macro_default_voll": 5000.0,
     }
@@ -1415,7 +1438,7 @@ def test_load_nsd_segments_error_and_missing_column_fallbacks(tmp_path):
     no_max_col_csv.write_text("Voll,Cost_of_Demand_Curtailment_per_MW\n2000,1\n")
     settings = {
         "input_folder": str(tmp_path),
-        "demand_segments_fn": "no_max_col.csv",
+        "demand_segments_table": "no_max_col.csv",
     }
     max_nsd, price_nsd = load_nsd_segments(settings)
     assert max_nsd == [1]
@@ -1426,7 +1449,7 @@ def test_load_nsd_segments_error_and_missing_column_fallbacks(tmp_path):
     no_price_col_csv.write_text("Max_Demand_Curtailment\n1\n")
     settings2 = {
         "input_folder": str(tmp_path),
-        "demand_segments_fn": "no_price_col.csv",
+        "demand_segments_table": "no_price_col.csv",
     }
     max_nsd, price_nsd = load_nsd_segments(settings2)
     assert max_nsd == [1]

--- a/tests/test_system/settings/extra_inputs.yml
+++ b/tests/test_system/settings/extra_inputs.yml
@@ -1,9 +1,9 @@
 # The location and name of additional input files needed to create outputs
 input_folder: extra_inputs # Subfolder directly below the location of this settings file
 # scenario_definitions_fn: scenario_inputs.csv # Define policy/cost scenarios for each case
-emission_policies_fn: emission_policies.csv # Emission policies for each model_year/region/case_id
+emission_policies_table: emission_policies.csv # Emission policies for each model_year/region/case_id
 # capacity_limit_spur_fn: resource_capacity_spur.csv # Max capacity and spur line distance for each renewable resource
-demand_segments_fn: demand_segments_voll.csv
+demand_segments_table: demand_segments_voll.csv
 user_transmission_costs: network_costs.csv
 co2_pipeline_cost_fn: co2_pipeline_cost_percentiles.csv
 # reserves_fn: Reserves.csv

--- a/tests/test_system/settings/macro.yml
+++ b/tests/test_system/settings/macro.yml
@@ -62,8 +62,8 @@
 # ---- fallback values used when source data is missing ----
 
 # Single-segment non-served-demand fallback when no demand-segments CSV
-# (demand_segments_fn) is configured: maximum curtailment fraction and
-# value of lost service in $/MWh.
+# (demand_segments_table; legacy alias demand_segments_fn) is configured:
+# maximum curtailment fraction and value of lost service in $/MWh.
 # macro_default_max_nsd: 1
 # macro_default_voll: 10000.0
 


### PR DESCRIPTION
## Why

PR #478 introduced the `emission_policies` and `demand_segments` tables to the DataManager, but wired them to settings keys ending in `_fn` (`emission_policies_fn`, `demand_segments_fn`). Every other DataManager table setting follows the `_table` convention (`generation_table`, `demand_table`, `fuel_price_table`, ...), so these two keys were inconsistent with the rest of the settings surface.

This PR renames the canonical settings to `emission_policies_table` and `demand_segments_table`, while keeping the old `_fn` keys working as aliases so existing user configs keep running unchanged.

## What changed

- **`powergenome/database.py`**: `STANDARD_TABLE_MAPPING` now uses `emission_policies_table` / `demand_segments_table`. Adds `STANDARD_TABLE_ALIASES` (canonical key -> legacy `_fn` key) and a module-level `get_table_setting_value(settings, setting_key)` helper that resolves a canonical key to its configured value, falling back to the legacy alias when the canonical key is unset (canonical wins if both are set). `DataManager._setup_tables()` and `DataManager.update()` resolve through this helper so alias configs load, reload, and compare consistently.
- **Consumers**: `validate._check_data_tables_loaded`, `macro_inputs.load_nsd_segments` (NSD segments gate), and `run_powergenome`'s ESR/CO2 output gate now resolve through the helper, so configs written with the old `_fn` keys keep working.
- **Docstrings**: `external_data.py` (`load_policy_scenarios`, `load_demand_segments`) and `GenX.py` (`add_emission_policies`) reference the `_table` names and note the alias.
- **Tests**: switched `database_test.py`, `external_data_test.py`, and `macro_test.py` to the `_table` keys, with new backwards-compatibility tests proving the `_fn` alias still loads tables and drives Macro NSD pricing. Also verifies `_table` takes precedence when both keys are set.
- **Sample settings + docs**: `tests/test_system/settings/extra_inputs.yml` and `macro.yml` plus docs (`data-tables.md`, `energy-share-requirements.md`, `configure-settings.md`, `pipeline.md`, `resource-tags.md`) now use the `_table` names and document the alias.

## Notes for reviewers

- The `example_systems/` configs and `settings_documentation.md` were intentionally left unchanged; the `_fn` alias keeps them working, and updating them is a separate task.
- If a user configures both `_table` and `_fn`, the canonical `_table` value wins.
- Unrelated legacy `*_fn` settings (`energy_share_req_fn`, `reserves_fn`, `cost_multiplier_fn`, etc.) are out of scope and unchanged.

## Validation

- Full test suite: 810 passed. The one failure (`test_fuzz_cluster_no_bin`, a DeadlineExceeded timeout under full-suite load) is unrelated flakiness and passes in isolation.
- Affected files (`database_test.py`, `external_data_test.py`, `macro_test.py`, `validate_test.py`, `cli_test.py`) re-run clean, formatted with black/isort.