### PR TITLE
Add release.yml for PyPI trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,16 @@ name: Publish Python Package
 # PyPI publisher config: Repository PowerGenome/PowerGenome, workflow
 # release.yml, environment name "release".
 #
-# To cut a release: bump the version in powergenome/version.py on main,
-# then run:
+# Automatic: push a new version tag, e.g.
 #   git tag v0.8.1 && git push origin v0.8.1
+# (after bumping the version in powergenome/version.py on main).
+#
+# Manual (e.g. to (re-)publish a previous release): run this workflow from
+# the Actions tab with a "Publish" event and a ref/tag to publish. The
+# sdist and wheel are built from that ref, so the version comes from its
+# powergenome/version.py. A GitHub release is created for the tag if one
+# does not exist yet; if it exists, the dist files are added to it.
+#
 # Tests already run on every push via pytest.yml, so this workflow only
 # builds and publishes.
 
@@ -14,17 +21,61 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      event:
+        description: What to do
+        type: choice
+        options:
+          - Publish
+          - Publish to TestPyPI
+        default: Publish
+      ref:
+        description: Tag or ref to publish (e.g. v0.8.0). Empty = latest version tag
+        type: string
+        default: ''
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.event == 'Publish to TestPyPI' && 'test-pypi' || 'release' }}
     permissions:
       id-token: write # trusted publishing (and build attestations)
       attestations: write
-      contents: write # create the GitHub release for the tag
+      contents: write # create/update the GitHub release for the tag
     steps:
+      # First checkout the default branch so tag listing works; the real
+      # checkout of the target ref happens in the next step.
       - uses: actions/checkout@v6
+
+      - name: Resolve ref to publish
+        id: target
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_REF}" ]; then
+            ref="${INPUT_REF}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            ref="${{ github.ref_name }}"
+          else
+            ref=$(git ls-remote --tags --refs origin 'v*' \
+              | awk '{print $2}' | sed 's|refs/tags/||' \
+              | grep -E '^v[0-9]+(\.[0-9]+)*$' \
+              | sort -V | tail -1)
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          # only plain numeric tags (v1.2.3) are stable; rc/a/b/dev are prereleases
+          name_no_v="${ref#v}"
+          case "$name_no_v" in
+            ''|*[!0-9.]*) prerelease=true ;;
+            *) prerelease=false ;;
+          esac
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.target.outputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -42,12 +93,40 @@ jobs:
         with:
           subject-path: dist/*
 
+      - name: Publish to TestPyPI
+        if: inputs.event == 'Publish to TestPyPI'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
       - name: Publish to PyPI
+        if: inputs.event != 'Publish to TestPyPI'
         uses: pypa/gh-action-pypi-publish@release/v1
 
+      - name: Check for existing GitHub release
+        id: ghrelease
+        run: |
+          if gh release view "${REF}" --json tagName > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          REF: ${{ steps.target.outputs.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create GitHub release
+        if: steps.ghrelease.outputs.exists == 'false'
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ github.ref_name }}
+          tag_name: ${{ steps.target.outputs.ref }}
           generate_release_notes: true
+          prerelease: ${{ steps.target.outputs.prerelease }}
           files: dist/*
+
+      - name: Add dist files to existing GitHub release
+        if: steps.ghrelease.outputs.exists == 'true'
+        run: gh release upload "${REF}" dist/* --clobber
+        env:
+          REF: ${{ steps.target.outputs.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       # First checkout the default branch so tag listing works; the real
       # checkout of the target ref happens in the next step.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Resolve ref to publish
         id: target
@@ -73,12 +73,12 @@ jobs:
         env:
           INPUT_REF: ${{ inputs.ref }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ steps.target.outputs.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -89,19 +89,19 @@ jobs:
         run: python -m build
 
       - name: Attest build artifacts
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: dist/*
 
       - name: Publish to TestPyPI
         if: inputs.event == 'Publish to TestPyPI'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1 (v1.14.2)
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish to PyPI
         if: inputs.event != 'Publish to TestPyPI'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1 (v1.14.2)
 
       - name: Check for existing GitHub release
         id: ghrelease
@@ -117,7 +117,7 @@ jobs:
 
       - name: Create GitHub release
         if: steps.ghrelease.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.target.outputs.ref }}
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Publish Python Package
+
+# Publish releases to PyPI via trusted publishing (no API token needed).
+# PyPI publisher config: Repository PowerGenome/PowerGenome, workflow
+# release.yml, environment name "release".
+#
+# To cut a release: bump the version in powergenome/version.py on main,
+# then run:
+#   git tag v0.8.1 && git push origin v0.8.1
+# Tests already run on every push via pytest.yml, so this workflow only
+# builds and publishes.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write # trusted publishing (and build attestations)
+      attestations: write
+      contents: write # create the GitHub release for the tag
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build backend
+        run: pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Attest build artifacts
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
## Why

PyPI now has GitHub registered as a trusted publisher for PowerGenome (repository `PowerGenome/PowerGenome`, workflow `release.yml`, environment `release`), but there was no working release workflow: the only branch with a `release.yml` (`gh-publish`) had the entire publish job commented out. This adds a clean workflow so tagged releases publish to PyPI without managing an API token.

It also enables publishing **previous** releases: `v0.8.0` is tagged on main but missing from PyPI (latest there is 0.7.0), and old tags have no `release.yml`, so a push-tag trigger alone cannot publish them (GitHub runs workflows as of the pushed ref).

## What it does

**Automatic**: pushing a `v*` tag triggers a single `publish` job that:

1. Builds sdist + wheel with `python -m build` (hatchling backend, version from `powergenome/version.py`)
2. Attests build provenance (`actions/attest-build-provenance@v2`)
3. Publishes to PyPI with `pypa/gh-action-pypi-publish@release/v1` using OIDC trusted publishing (`id-token: write`, `environment: release` to match the registered publisher)
4. Creates the matching GitHub release with auto-generated notes and the dist files attached (`softprops/action-gh-release@v2`)

**Manual** (`workflow_dispatch` from the Actions tab):
- `ref` input: any tag or ref to publish (e.g. `v0.8.0`); empty = latest numeric version tag. The dist is built from that ref, so the published version matches the tag.
- `event` input: `Publish` or `Publish to TestPyPI` (TestPyPI uses a `test-pypi` environment if you create one).
- GitHub release step is idempotent: creates the release if missing, otherwise uploads/overwrites the dist assets on the existing release. Tags with `rc`/`a`/`b`/`dev` suffixes are marked prerelease.

## Notes for reviewers

- No test job here: `pytest.yml` already runs the suite on every push, and tags are cut from tested commits on main.
- The `release` environment must exist in repo settings (it can be created empty; the job references it by name).
- Release flow after merge: bump `powergenome/version.py`, then `git tag v0.8.1 && git push origin v0.8.1`.
- To publish 0.8.0 after merge: Actions -> Publish Python Package -> Run workflow -> ref `v0.8.0`.
- Verified locally that `python -m build` produces `powergenome-0.8.0` sdist and wheel with the `data/` package included.
